### PR TITLE
Provide PNGjs instance to new Image()

### DIFF
--- a/__tests__/graphics/Image.spec.ts
+++ b/__tests__/graphics/Image.spec.ts
@@ -1,9 +1,30 @@
-import { load } from '../helper'
-import { Image } from '../../src'
+import { load } from '../helper';
+import { Image } from '../../src';
+import { PNG } from 'pngjs';
 
 describe('proccess images to printing format', () => {
   it('load image from buffer', () => {
-    const image = new Image(load('sample.png'))
-    expect(image.width).toBe(180)
-  })
-})
+    const image = new Image(load('sample.png'));
+    expect(image.width).toBe(180);
+  });
+
+  it('accepts a pre-loaded PNG instance', async () => {
+    const imageBuffer = load('sample.png');
+
+    const png = await new Promise((resolve: Function, reject: Function) => {
+      new PNG({ filterType: 4 }).parse(
+        imageBuffer,
+        (error: Error, data: Buffer) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve(data);
+        },
+      );
+    });
+
+    const image = new Image(png);
+    expect(image.width).toBe(180);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "escpos-buffer",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Library to generate buffer for thermal printers.",
   "author": "GrandChef Team <desenvolvimento@grandchef.com.br>",
   "license": "MIT",

--- a/src/graphics/Image.ts
+++ b/src/graphics/Image.ts
@@ -8,21 +8,23 @@ export default class Image {
   width: number;
   bytesPerRow: number;
 
-  constructor(input: string | Buffer, filter: Filter = null) {
-    const _filter = filter || new FloydSteinberg();
-    if (typeof input === 'string') {
-      this.loadImage(input, _filter);
+  constructor(
+    input: string | Buffer | PNG,
+    filter: Filter = new FloydSteinberg(),
+  ) {
+    if (input instanceof PNG) {
+      this.readImage(filter.process(input));
+    } else if (typeof input === 'string') {
+      this.loadImage(input, filter);
     } else {
-      this.loadImageData(input, _filter);
+      this.loadImageData(input, filter);
     }
   }
 
   loadImage(filename: string, filter: Filter): void {
     // tslint:disable-next-line: non-literal-fs-path
     const data = fs.readFileSync(filename);
-    const png = PNG.sync.read(data);
-    const image = filter.process(png);
-    this.readImage(image);
+    this.loadImageData(data, filter);
   }
 
   loadImageData(data: Buffer, filter: Filter): void {


### PR DESCRIPTION
In the browser, for some reason in the browser `fetch()`ing a PNG and providing the buffer to `new Image()` gives an error like `cannot read property interface of undefined`.
Looks like a known bug: https://github.com/lukeapage/pngjs/issues/120
It can be worked around by loading the image `async`ly - but since you can't have an async constructor, this PR allows you to provide a pre-loaded `PNG` instance from `pngjs` instead of a buffer.
This allows Image printing using WebUSB.