### PR TITLE
Select correct interface for WebUSB

### DIFF
--- a/__tests__/connection/WebUSB.spec.ts
+++ b/__tests__/connection/WebUSB.spec.ts
@@ -1,7 +1,30 @@
 import WebUSB from '../../src/connection/WebUSB';
 
+const OUT_ENDPOINT_NUMBER = 2;
+
 describe('WebUSB', () => {
   const device = ({
+    configuration: {
+      interfaces: [
+        {
+          alternate: {
+            endpoints: [
+              { direction: 'in', endpointNumber: 1 },
+              { direction: 'out', endpointNumber: OUT_ENDPOINT_NUMBER },
+            ],
+          },
+        },
+        {
+          alternate: {
+            endpoints: [
+              { direction: 'in', endpointNumber: 1 },
+              { direction: 'in', endpointNumber: 2 },
+              { direction: 'out', endpointNumber: 3 },
+            ],
+          },
+        },
+      ],
+    },
     open: jest.fn().mockReturnValue(Promise.resolve()),
     selectConfiguration: jest.fn().mockReturnValue(Promise.resolve()),
     claimInterface: jest.fn().mockReturnValue(Promise.resolve()),
@@ -22,8 +45,22 @@ describe('WebUSB', () => {
   it('writes data', async () => {
     const buffer = Buffer.from('hello');
     const webUsb = new WebUSB(device);
+    await webUsb.open();
     await webUsb.write(buffer);
-    expect(device.transferOut).toHaveBeenCalledWith(1, buffer);
+    expect(device.transferOut).toHaveBeenCalledWith(
+      OUT_ENDPOINT_NUMBER,
+      buffer,
+    );
+  });
+
+  it('allows override of configuration and interface', async () => {
+    const webUsb = new WebUSB(device);
+    const configuration = 2;
+    const interfaceNumber = 1;
+    await webUsb.open({ configuration, interface: interfaceNumber });
+    expect(device.open).toHaveBeenCalledTimes(1);
+    expect(device.selectConfiguration).toHaveBeenCalledWith(configuration);
+    expect(device.claimInterface).toHaveBeenCalledWith(interfaceNumber);
   });
 
   it('closes the connection', async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "escpos-buffer",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Library to generate buffer for thermal printers.",
   "author": "GrandChef Team <desenvolvimento@grandchef.com.br>",
   "license": "MIT",


### PR DESCRIPTION
Previously this was hard-coded to 1, but different models of printers will expose different interfaces. This will select the correct one based on the `out` direction.