### PR TITLE
Add withStyle function to Printer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ printer.write('Simple Text *** ')
 printer.writeln('Bold Text -> complete line text.[]123456', Style.Bold)
 printer.writeln('Double height', Style.DoubleHeight | Style.Bold, Align.Center)
 printer.writeln('Áçênts R$ 5,00', Style.DoubleWidth | Style.DoubleWidth, Align.Center)
+printer.withStyle({
+  width: 4,
+  height: 6,
+  bold: true,
+  italic: true,
+  underline: true,
+  align: Align.Center,
+  }, () => {
+    printer.writeln('You can apply multiple styles at once using withStyle()')
+    printer.writeln('Font sizes 1-8 are available')
+})
+printer.writeln('Default style is restored afterwards')
 printer.feed(6)
 printer.buzzer()
 printer.cutter()

--- a/__tests__/Printer.spec.ts
+++ b/__tests__/Printer.spec.ts
@@ -1,11 +1,12 @@
-import Model from '../src/Model';
-import InMemory from '../src/connection/InMemory';
-import Printer, { Style, Align } from '../src/Printer';
-import { load } from './helper';
-import { Image } from '../src';
 import * as path from 'path';
+import { Image } from '../src';
 import { Capability } from '../src/capabilities';
+import InMemory from '../src/connection/InMemory';
+import Model from '../src/Model';
+import Printer, { Align, Style } from '../src/Printer';
+import { StyleConf } from '../src/profile';
 import Elgin from '../src/profile/Elgin';
+import { load } from './helper';
 
 describe('print formatted text', () => {
   it('write text', () => {
@@ -230,5 +231,24 @@ describe('print formatted text', () => {
       const model = new Model('MP-4200 TH');
       model.profile.feed(1);
     }).toThrow();
+  });
+
+  it('should forward withStyle to the profile', () => {
+    const connection = new InMemory();
+    const model = new Model('MP-4200 TH');
+    const withStyleSpy = jest
+      .spyOn(model.profile, 'withStyle')
+      .mockImplementation((_: StyleConf, cb: Function) => cb());
+    const printer = new Printer(model, connection);
+
+    const styleConf = {
+      width: 4,
+      height: 8,
+    };
+    const cb = jest.fn();
+    printer.withStyle(styleConf, cb);
+
+    expect(withStyleSpy).toHaveBeenCalledWith(styleConf, cb);
+    expect(cb).toHaveBeenCalledTimes(1);
   });
 });

--- a/__tests__/profile/Epson.spec.ts
+++ b/__tests__/profile/Epson.spec.ts
@@ -1,35 +1,123 @@
-import Model from '../../src/Model'
-import InMemory from '../../src/connection/InMemory'
-import Printer, { Align, Style } from '../../src/Printer'
-import { load } from '../helper'
+import Model from '../../src/Model';
+import InMemory from '../../src/connection/InMemory';
+import Printer, { Align, Style } from '../../src/Printer';
+import { load } from '../helper';
 
 describe('epson model profile', () => {
   it('write text from model TM-T20', () => {
-    const connection = new InMemory()
-    const model = new Model('TM-T20')
-    const printer = new Printer(model, connection)
-    printer.writeln('Large Text')
-    expect(connection.buffer()).toStrictEqual(load('tm-t20_text', connection.buffer()))
-  })
+    const connection = new InMemory();
+    const model = new Model('TM-T20');
+    const printer = new Printer(model, connection);
+    printer.writeln('Large Text');
+    expect(connection.buffer()).toStrictEqual(
+      load('tm-t20_text', connection.buffer()),
+    );
+  });
 
   it('write text with double width and height from model TM-T20', () => {
-    const connection = new InMemory()
-    const model = new Model('TM-T20')
-    const printer = new Printer(model, connection)
-    printer.columns = 64
-    printer.writeln('Large Text', Style.DoubleWidth + Style.DoubleHeight, Align.Center)
-    printer.feed(2)
-    printer.feed(255)
-    expect(model.profile.font.name).toBe('Font B')
-    expect(connection.buffer()).toStrictEqual(load('tm-t20_large_text_font', connection.buffer()))
-  })
+    const connection = new InMemory();
+    const model = new Model('TM-T20');
+    const printer = new Printer(model, connection);
+    printer.columns = 64;
+    printer.writeln(
+      'Large Text',
+      Style.DoubleWidth + Style.DoubleHeight,
+      Align.Center,
+    );
+    printer.feed(2);
+    printer.feed(255);
+    expect(model.profile.font.name).toBe('Font B');
+    expect(connection.buffer()).toStrictEqual(
+      load('tm-t20_large_text_font', connection.buffer()),
+    );
+  });
 
   it('draw qrcode from model TM-T20', async () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('TM-T20'), connection)
-    printer.alignment = Align.Center
-    await printer.qrcode('https://github.com/grandchef/escpos-buffer')
-    printer.alignment = Align.Left
-    expect(connection.buffer()).toStrictEqual(load('tm-t20_qrcode', connection.buffer()))
-  })
-})
+    const connection = new InMemory();
+    const printer = new Printer(new Model('TM-T20'), connection);
+    printer.alignment = Align.Center;
+    await printer.qrcode('https://github.com/grandchef/escpos-buffer');
+    printer.alignment = Align.Left;
+    expect(connection.buffer()).toStrictEqual(
+      load('tm-t20_qrcode', connection.buffer()),
+    );
+  });
+
+  it('sets char size from the style and clears it after', () => {
+    const connection = new InMemory();
+    const printer = new Printer(new Model('TM-T20'), connection);
+    const cb = jest.fn();
+    const width = 4;
+    const height = 6;
+    printer.withStyle({ width, height }, cb);
+    const expectedN = (height - 1) | ((width - 1) << 4);
+
+    const buffer = connection.buffer();
+    const setCharSizeCmd = [...buffer.slice(3, 6)];
+    const clearCharSizeCmd = [...buffer.slice(6, 9)];
+    expect(setCharSizeCmd).toEqual([0x1d, 0x21, expectedN]);
+    expect(clearCharSizeCmd).toEqual([0x1d, 0x21, 0x00]);
+  });
+
+  it('defaults width to 1', () => {
+    const connection = new InMemory();
+    const printer = new Printer(new Model('TM-T20'), connection);
+    const cb = jest.fn();
+    const height = 6;
+    printer.withStyle({ height }, cb);
+
+    const expectedWidth = 1;
+    const expectedN = (height - 1) | ((expectedWidth - 1) << 4);
+    const buffer = connection.buffer();
+    expect(buffer[5]).toBe(expectedN);
+  });
+
+  it('defaults height to 1', () => {
+    const connection = new InMemory();
+    const printer = new Printer(new Model('TM-T20'), connection);
+    const cb = jest.fn();
+    const width = 6;
+    printer.withStyle({ width }, cb);
+
+    const expectedHeight = 1;
+    const expectedN = (expectedHeight - 1) | ((width - 1) << 4);
+    const buffer = connection.buffer();
+    expect(buffer[5]).toBe(expectedN);
+  });
+
+  it('caps max char size at 8', () => {
+    const connection = new InMemory();
+    const printer = new Printer(new Model('TM-T20'), connection);
+    const cb = jest.fn();
+    printer.withStyle(
+      {
+        width: 15,
+        height: 10,
+      },
+      cb,
+    );
+
+    const expectedHeight = 8;
+    const expectedWidth = 8;
+    const expectedN = (expectedHeight - 1) | ((expectedWidth - 1) << 4);
+    const buffer = connection.buffer();
+    expect(buffer[5]).toBe(expectedN);
+  });
+
+  it('caps min char size at 1', () => {
+    const connection = new InMemory();
+    const printer = new Printer(new Model('TM-T20'), connection);
+    const cb = jest.fn();
+    printer.withStyle(
+      {
+        width: -1,
+        height: -1,
+      },
+      cb,
+    );
+
+    const expectedN = 0;
+    const buffer = connection.buffer();
+    expect(buffer[5]).toBe(expectedN);
+  });
+});

--- a/__tests__/profile/index.spec.ts
+++ b/__tests__/profile/index.spec.ts
@@ -1,0 +1,92 @@
+import { Profile } from '../../src/profile';
+import { Capability } from '../../src/capabilities';
+import { Style, Align, Cut, Drawer } from '../../src';
+
+class MockProfile extends Profile {
+  get alignment() {
+    return null;
+  }
+  set alignment(_: number) {}
+  feed: (lines: number) => void = jest.fn();
+  cutter: (mode: Cut) => void = jest.fn();
+  buzzer: () => void = jest.fn();
+  drawer: (number: Drawer, on_time: number, off_time: number) => void = jest.fn();
+  qrcode: (data: string, size: number) => Promise<void> = jest.fn();
+  setMode: (mode: number, enable: boolean) => void = jest.fn();
+  setStyle: (style: Style, enable: boolean) => void = jest.fn();
+  setStyles: (styles: number, enable: boolean) => void = jest.fn();
+  setCharSize: (charSize: { width: number, height: number }) => void = jest.fn();
+}
+const capability: Capability = {
+  columns: 42,
+  profile: 'epson',
+  model: 'A123',
+  brand: 'Custom',
+  codepage: 'utf8',
+  codepages: [
+    {
+      code: 'utf8',
+      command: '',
+    },
+  ],
+  fonts: [
+    {
+      name: 'Font A',
+      columns: 42,
+    },
+  ],
+};
+
+describe('Profile', () => {
+  afterEach(() => jest.resetAllMocks());
+  describe('withStyle', () => {
+    it('should apply font size and then unapply it after calling the callback', () => {
+      const profile = new MockProfile(capability);
+      const styleConf = {
+        width: 4,
+        height: 8,
+      };
+      const cb = jest.fn();
+
+      profile.withStyle(styleConf, cb);
+
+      expect(profile.setCharSize).toHaveBeenCalledWith({ ...styleConf });
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(profile.setCharSize).toHaveBeenCalledWith({ width: 1, height: 1 });
+    });
+
+    it('should apply style and then unapply it after calling the callback', () => {
+      const profile = new MockProfile(capability);
+      const styleConf = {
+        bold: true,
+        italic: true,
+        underline: true,
+      };
+      const cb = jest.fn();
+
+      profile.withStyle(styleConf, cb);
+
+      const expectedStyles = Style.Bold | Style.Italic | Style.Underline;
+
+      expect(profile.setStyles).toHaveBeenCalledWith(expectedStyles, true);
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(profile.setStyles).toHaveBeenCalledWith(expectedStyles, false);
+    });
+
+    it('should apply alignment and then unapply it after calling the callback', () => {
+      const profile = new MockProfile(capability);
+      const alignmentSetter = jest.spyOn(profile, 'alignment', 'set');
+      const align = Align.Center;
+      const styleConf = {
+        align,
+      };
+      const cb = jest.fn();
+
+      profile.withStyle(styleConf, cb);
+
+      expect(alignmentSetter).toHaveBeenCalledWith(align);
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(alignmentSetter).toHaveBeenCalledWith(Align.Left);
+    });
+  });
+});

--- a/src/Printer.ts
+++ b/src/Printer.ts
@@ -1,6 +1,7 @@
 import Model from './Model';
 import { Connection } from './connection';
 import Image from './graphics/Image';
+import { StyleConf } from './profile';
 
 export enum Align {
   Left,
@@ -80,6 +81,10 @@ export default class Printer {
 
   writeln(text: string = '', styles: number = 0, align: Align = Align.Left) {
     this.model.profile.writeln(text, styles, align);
+  }
+
+  withStyle(styleConf: StyleConf, cb: Function) {
+    this.model.profile.withStyle(styleConf, cb);
   }
 
   feed(lines: number = 1) {

--- a/src/profile/Epson.ts
+++ b/src/profile/Epson.ts
@@ -102,6 +102,22 @@ export default class Epson extends Profile {
     }
   }
 
+  protected setCharSize({
+    width = 1,
+    height = 1,
+  }: {
+    width: number;
+    height: number;
+  }) {
+    width = Math.max(1, Math.min(width, 8));
+    height = Math.max(1, Math.min(height, 8));
+    const n = (height - 1) | ((width - 1) << 4);
+
+    this.connection.write(
+      Buffer.from(`\x1D!${String.fromCharCode(n)}`, 'ascii'),
+    );
+  }
+
   async qrcode(data: string, size: number) {
     const tipo = '2';
     const _size = String.fromCharCode(size || 4);


### PR DESCRIPTION
Allows for usage of larger font sizes and to apply a few styles at once, and have them automatically reverted after writing some text.

Fixes https://github.com/grandchef/escpos-buffer/issues/7

Example usage:
```js
printer.withStyle({
  width: 4,
  height: 6,
  bold: true,
  italic: true,
  underline: true,
  align: Align.Center,
  }, () => {
    printer.writeln('You can apply multiple styles at once using withStyle()')
    printer.writeln('Font sizes 1-8 are available')
})
```