### PR TITLE
Exposes the async nature of WebUSB

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status][github-badge]][github-ci]
 [![TypeScript version][ts-badge]][typescript-37]
 [![Node.js version][nodejs-badge]][nodejs]
-[![MIT][license-badge]][LICENSE]
+[![MIT][license-badge]][license]
 
 # ESC/POS Printer Library
 
@@ -15,24 +15,60 @@ Run command bellow on your project folder
 ```sh
 yarn add escpos-buffer
 ```
+
 or
+
 ```sh
 npm install escpos-buffer
 ```
 
-## Basic example
-```js
-const { Printer, Style, Align, Drawer, Model, InMemory } = require('escpos-buffer')
+## Setup
 
-const model = new Model('MP-4200 TH')
-const connection = new InMemory()
-const printer = new Printer(model, connection)
-printer.columns = 56
-printer.write('Simple Text *** ')
-printer.writeln('Bold Text -> complete line text.[]123456', Style.Bold)
-printer.writeln('Double height', Style.DoubleHeight | Style.Bold, Align.Center)
-printer.writeln('Áçênts R$ 5,00', Style.DoubleWidth | Style.DoubleWidth, Align.Center)
-printer.withStyle({
+### Node
+
+```js
+const {
+  Printer,
+  Style,
+  Align,
+  Drawer,
+  Model,
+  InMemory,
+} = require('escpos-buffer');
+
+const model = new Model('MP-4200 TH');
+const connection = new InMemory();
+const printer = new Printer(model, connection);
+```
+
+### Browser
+
+Use the WebUSB protocol [in Chrome](https://caniuse.com/webusb) to connect directly to the printer.
+
+```js
+import { Printer, Model, WebUSB } from 'escpos-buffer';
+
+const device = await navigator.usb.requestDevice({
+  filters: [
+    {
+      vendorId: VENDOR_ID,
+    },
+  ],
+});
+const connection = new WebUSB(device);
+const printer = await Printer.connect('TM-T20', connection);
+```
+
+## Usage
+
+```js
+// Following setup above...
+await printer.columns = 56
+await printer.write('Simple Text *** ')
+await printer.writeln('Bold Text -> complete line text.[]123456', Style.Bold)
+await printer.writeln('Double height', Style.DoubleHeight | Style.Bold, Align.Center)
+await printer.writeln('Áçênts R$ 5,00', Style.DoubleWidth | Style.DoubleWidth, Align.Center)
+await printer.withStyle({
   width: 4,
   height: 6,
   bold: true,
@@ -43,11 +79,11 @@ printer.withStyle({
     printer.writeln('You can apply multiple styles at once using withStyle()')
     printer.writeln('Font sizes 1-8 are available')
 })
-printer.writeln('Default style is restored afterwards')
-printer.feed(6)
-printer.buzzer()
-printer.cutter()
-printer.drawer(Drawer.First)
+await printer.writeln('Default style is restored afterwards')
+await printer.feed(6)
+await printer.buzzer()
+await printer.cutter()
+await printer.drawer(Drawer.First)
 process.stdout.write(connection.buffer())
 
 // to print, run command bellow on terminal
@@ -55,48 +91,30 @@ process.stdout.write(connection.buffer())
 ```
 
 ## Usage in the browser
-You can also use the new WebUSB protocol [in Chrome](https://caniuse.com/webusb) to connect directly to the printer.
-```js
-import { Printer, Model, WebUSB } from 'escpos-buffer'
-
-const device = await navigator.usb.requestDevice({
-  filters: [{
-    vendorId: VENDOR_ID
-  }]
-})
-const model = new Model('TM-T20')
-const connection = new WebUSB(device)
-await connection.open()
-const printer = new Printer(model, connection)
-// ...
-```
 
 ## Available scripts
 
-+ `clean` - remove coverage data, Jest cache and transpiled files,
-+ `build` - transpile TypeScript to ES6,
-+ `build:watch` - interactive watch mode to automatically transpile source files,
-+ `lint` - lint source files and tests,
-+ `style:fix` - fix prettier style problems,
-+ `style:check` - check for prettier style,
-+ `test` - run tests,
-+ `test:watch` - interactive watch mode to automatically re-run tests
-+ `test:debug` - run tests debugging
+- `clean` - remove coverage data, Jest cache and transpiled files,
+- `build` - transpile TypeScript to ES6,
+- `build:watch` - interactive watch mode to automatically transpile source files,
+- `lint` - lint source files and tests,
+- `style:fix` - fix prettier style problems,
+- `style:check` - check for prettier style,
+- `test` - run tests,
+- `test:watch` - interactive watch mode to automatically re-run tests
+- `test:debug` - run tests debugging
 
 ## License
+
 Licensed under the MIT. See the [LICENSE](https://github.com/grandchef/escpos-buffer/blob/master/LICENSE) file for details.
 
 [ts-badge]: https://img.shields.io/badge/TypeScript-3.7-blue.svg
 [typescript-37]: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html
-
 [nodejs-badge]: https://img.shields.io/badge/Node.js->=%2010-blue.svg
 [nodejs]: https://nodejs.org/dist/latest-v10.x/docs/api/
-
 [github-badge]: https://github.com/grandchef/escpos-buffer/actions/workflows/main.yml/badge.svg
 [github-ci]: https://github.com/grandchef/escpos-buffer/actions
-
 [license-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [license]: https://github.com/grandchef/escpos-buffer/blob/master/LICENSE
-
 [version-badge]: https://img.shields.io/npm/v/escpos-buffer?label=escpos-buffer
 [npm-link]: https://www.npmjs.com/package/escpos-buffer

--- a/README.md
+++ b/README.md
@@ -27,14 +27,7 @@ npm install escpos-buffer
 ### Node
 
 ```js
-const {
-  Printer,
-  Style,
-  Align,
-  Drawer,
-  Model,
-  InMemory,
-} = require('escpos-buffer');
+const { Printer, Model, InMemory } = require('escpos-buffer');
 
 const model = new Model('MP-4200 TH');
 const connection = new InMemory();

--- a/README.md
+++ b/README.md
@@ -27,11 +27,10 @@ npm install escpos-buffer
 ### Node
 
 ```js
-const { Printer, Model, InMemory } = require('escpos-buffer');
+const { Printer, InMemory } = require('escpos-buffer');
 
-const model = new Model('MP-4200 TH');
 const connection = new InMemory();
-const printer = new Printer(model, connection);
+const printer = new Printer('MP-4200 TH', connection);
 ```
 
 ### Browser

--- a/__tests__/Model.spec.ts
+++ b/__tests__/Model.spec.ts
@@ -1,13 +1,13 @@
 import Model from '../src/Model';
 
 describe('load model', () => {
-  it('load model MP-4200 TH from Bematech', () => {
-    const model = new Model('MP-4200 TH');
+  it('load model MP-4200 TH from Bematech', async () => {
+    const model = await Model.initialise('MP-4200 TH');
     expect(model.name).toBe('Bematech MP-4200 TH');
   });
 
-  it('load model TM-T20 from Epson', () => {
-    const model = new Model('TM-T20');
+  it('load model TM-T20 from Epson', async () => {
+    const model = await Model.initialise('TM-T20');
     expect(model.name).toBe('Epson TM-T20');
   });
 });

--- a/__tests__/Model.spec.ts
+++ b/__tests__/Model.spec.ts
@@ -2,12 +2,12 @@ import Model from '../src/Model';
 
 describe('load model', () => {
   it('load model MP-4200 TH from Bematech', async () => {
-    const model = await Model.initialise('MP-4200 TH');
+    const model = new Model('MP-4200 TH');
     expect(model.name).toBe('Bematech MP-4200 TH');
   });
 
   it('load model TM-T20 from Epson', async () => {
-    const model = await Model.initialise('TM-T20');
+    const model = new Model('TM-T20');
     expect(model.name).toBe('Epson TM-T20');
   });
 });

--- a/__tests__/Printer.spec.ts
+++ b/__tests__/Printer.spec.ts
@@ -3,7 +3,9 @@ import { Image } from '../src';
 import { Capability } from '../src/capabilities';
 import InMemory from '../src/connection/InMemory';
 import Model from '../src/Model';
-import Printer, { Align, Style } from '../src/Printer';
+import Printer from '../src/Printer';
+import { Align } from '../src/Align';
+import { Style } from '../src/Style';
 import { StyleConf, Profile } from '../src/profile';
 import Elgin from '../src/profile/Elgin';
 import { load } from './helper';
@@ -11,10 +13,7 @@ import { load } from './helper';
 describe('print formatted text', () => {
   it('write text', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('TM-T20'),
-      connection,
-    );
+    const printer = await Printer.connect('TM-T20', connection);
     await printer.write('Simple Text');
     await printer.feed();
     expect(connection.buffer()).toStrictEqual(
@@ -24,10 +23,7 @@ describe('print formatted text', () => {
 
   it('write line', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('TM-T20'),
-      connection,
-    );
+    const printer = await Printer.connect('TM-T20', connection);
     await printer.writeln('Simple Line');
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_write_line', connection.buffer()),
@@ -36,10 +32,7 @@ describe('print formatted text', () => {
 
   it('write empty line', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('TM-T20'),
-      connection,
-    );
+    const printer = await Printer.connect('TM-T20', connection);
     await printer.writeln();
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_write_empty_line', connection.buffer()),
@@ -48,10 +41,7 @@ describe('print formatted text', () => {
 
   it('write bold text', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('TM-T20'),
-      connection,
-    );
+    const printer = await Printer.connect('TM-T20', connection);
     await printer.writeln('Bold text', Style.Bold, Align.Center);
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_bold_text', connection.buffer()),
@@ -60,10 +50,7 @@ describe('print formatted text', () => {
 
   it('write text with double width and height', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('TM-T20'),
-      connection,
-    );
+    const printer = await Printer.connect('TM-T20', connection);
     await printer.writeln(
       'Large Text',
       Style.DoubleWidth + Style.DoubleHeight,
@@ -76,10 +63,7 @@ describe('print formatted text', () => {
 
   it('write italic text', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('TM-T20'),
-      connection,
-    );
+    const printer = await Printer.connect('TM-T20', connection);
     await printer.writeln('Italic Text', Style.Italic, Align.Center);
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_italic_text', connection.buffer()),
@@ -88,10 +72,7 @@ describe('print formatted text', () => {
 
   it('write underline text', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('TM-T20'),
-      connection,
-    );
+    const printer = await Printer.connect('TM-T20', connection);
     await printer.writeln('Underline Text', Style.Underline, Align.Center);
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_underline_text', connection.buffer()),
@@ -100,10 +81,7 @@ describe('print formatted text', () => {
 
   it('write condensed text', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('TM-T20'),
-      connection,
-    );
+    const printer = await Printer.connect('TM-T20', connection);
     await printer.writeln('Condensed Text', Style.Condensed, Align.Center);
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_condensed_text', connection.buffer()),
@@ -112,10 +90,7 @@ describe('print formatted text', () => {
 
   it('draw qrcode', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('MP-4200 TH'),
-      connection,
-    );
+    const printer = await Printer.connect('MP-4200 TH', connection);
     await printer.setAlignment(Align.Center);
     await printer.qrcode('https://github.com/grandchef/escpos-buffer');
     await printer.setAlignment(Align.Left);
@@ -126,10 +101,7 @@ describe('print formatted text', () => {
 
   it('emit buzzer', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('TM-T20'),
-      connection,
-    );
+    const printer = await Printer.connect('TM-T20', connection);
     await printer.buzzer();
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_buzzer', connection.buffer()),
@@ -138,10 +110,7 @@ describe('print formatted text', () => {
 
   it('activate drawer', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('TM-T20'),
-      connection,
-    );
+    const printer = await Printer.connect('TM-T20', connection);
     await printer.drawer();
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_drawer', connection.buffer()),
@@ -150,10 +119,7 @@ describe('print formatted text', () => {
 
   it('cut paper', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('TM-T20'),
-      connection,
-    );
+    const printer = await Printer.connect('TM-T20', connection);
     await printer.cutter();
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_cut', connection.buffer()),
@@ -162,10 +128,7 @@ describe('print formatted text', () => {
 
   it('draw picture from file', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('MP-4200 TH'),
-      connection,
-    );
+    const printer = await Printer.connect('MP-4200 TH', connection);
     const image = new Image(path.join(__dirname, 'resources/sample.png'));
     await printer.setAlignment(Align.Center);
     await printer.draw(image);
@@ -177,10 +140,7 @@ describe('print formatted text', () => {
 
   it('draw picture from buffer', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('MP-4200 TH'),
-      connection,
-    );
+    const printer = await Printer.connect('MP-4200 TH', connection);
     const image = new Image(load('sample.png'));
     await printer.setAlignment(Align.Center);
     await printer.draw(image);
@@ -211,17 +171,15 @@ describe('print formatted text', () => {
         },
       ],
     };
-    const profile = await Profile.initialise(Elgin,capability);
+    const profile = new Elgin(capability);
     const model = new Model(profile);
+    await Printer.connect(model, new InMemory());
     expect(model.profile.font.name).toBe('Font A');
   });
 
   it('check default columns', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('MP-4200 TH'),
-      connection,
-    );
+    const printer = await Printer.connect('MP-4200 TH', connection);
     const capability = Model.ALL().find(
       ({ model }: Capability) => model == 'MP-4200 TH',
     );
@@ -229,17 +187,15 @@ describe('print formatted text', () => {
   });
 
   it('change columns', async () => {
-    const connection = new InMemory();
-    const model = await Model.initialise('MP-4200 TH');
-    const printer = await Printer.connect(model, connection);
+    const model = new Model('MP-4200 TH');
+    const printer = new Printer(model);
     await printer.setColumns(42);
     expect(model.profile.font.name).toBe('Font A');
   });
 
   it('overflow columns', async () => {
-    const connection = new InMemory();
-    const model = await Model.initialise('MP-4200 TH');
-    const printer = await Printer.connect(model, connection);
+    const model = new Model('MP-4200 TH');
+    const printer = new Printer(model);
     await printer.setColumns(62);
     expect(model.profile.font.name).toBe('Font B');
     expect(printer.columns).toBe(56);
@@ -247,7 +203,7 @@ describe('print formatted text', () => {
 
   it('change codepage', async () => {
     const connection = new InMemory();
-    const model = await Model.initialise('MP-4200 TH');
+    const model = 'MP-4200 TH';
     const printer = await Printer.connect(model, connection);
     await printer.setCodepage('utf8');
     await printer.writeln('Açênts');
@@ -256,29 +212,23 @@ describe('print formatted text', () => {
     );
   });
 
-  it('unsupported model', async () => {
-    expect(Model.initialise('Unknow Model')).rejects.toThrow();
-  });
-
   it('unsupported codepage', async () => {
-    const connection = new InMemory();
-    const model = await Model.initialise('MP-4200 TH');
-    const printer = await Printer.connect(model, connection);
+    const model = new Model('MP-4200 TH');
+    const printer = new Printer(model);
     expect(printer.setCodepage('utf9')).rejects.toThrow();
   });
 
   it('write without connection', async () => {
-    const model = await Model.initialise('MP-4200 TH');
+    const model = new Model('MP-4200 TH');
     await expect(model.profile.feed(1)).rejects.toThrow();
   });
 
   it('should forward withStyle to the profile', async () => {
-    const connection = new InMemory();
-    const model = await Model.initialise('MP-4200 TH');
+    const model = new Model('MP-4200 TH');
     const withStyleSpy = jest
       .spyOn(model.profile, 'withStyle')
       .mockImplementation((_: StyleConf, cb: Function) => cb());
-    const printer = await Printer.connect(model, connection);
+    const printer = new Printer(model);
 
     const styleConf = {
       width: 4,

--- a/__tests__/Printer.spec.ts
+++ b/__tests__/Printer.spec.ts
@@ -225,14 +225,14 @@ describe('print formatted text', () => {
     const capability = Model.ALL().find(
       ({ model }: Capability) => model == 'MP-4200 TH',
     );
-    expect(printer.columns).toBe(capability.columns);
+    expect(printer.setColumns).toBe(capability.columns);
   });
 
   it('change columns', async () => {
     const connection = new InMemory();
     const model = new Model('MP-4200 TH');
     const printer = await Printer.connectPrinter(model, connection);
-    printer.columns = 42;
+    printer.setColumns = 42;
     expect(model.profile.font.name).toBe('Font A');
   });
 
@@ -240,9 +240,9 @@ describe('print formatted text', () => {
     const connection = new InMemory();
     const model = new Model('MP-4200 TH');
     const printer = await Printer.connectPrinter(model, connection);
-    printer.columns = 62;
+    printer.setColumns = 62;
     expect(model.profile.font.name).toBe('Font B');
-    expect(printer.columns).toBe(56);
+    expect(printer.setColumns).toBe(56);
   });
 
   it('change codepage', async () => {

--- a/__tests__/Printer.spec.ts
+++ b/__tests__/Printer.spec.ts
@@ -12,7 +12,7 @@ describe('print formatted text', () => {
   it('write text', async () => {
     const connection = new InMemory();
     const printer = await Printer.connect(
-      new Model('TM-T20'),
+      await Model.initialise('TM-T20'),
       connection,
     );
     await printer.write('Simple Text');
@@ -25,7 +25,7 @@ describe('print formatted text', () => {
   it('write line', async () => {
     const connection = new InMemory();
     const printer = await Printer.connect(
-      new Model('TM-T20'),
+      await Model.initialise('TM-T20'),
       connection,
     );
     await printer.writeln('Simple Line');
@@ -37,7 +37,7 @@ describe('print formatted text', () => {
   it('write empty line', async () => {
     const connection = new InMemory();
     const printer = await Printer.connect(
-      new Model('TM-T20'),
+      await Model.initialise('TM-T20'),
       connection,
     );
     await printer.writeln();
@@ -49,7 +49,7 @@ describe('print formatted text', () => {
   it('write bold text', async () => {
     const connection = new InMemory();
     const printer = await Printer.connect(
-      new Model('TM-T20'),
+      await Model.initialise('TM-T20'),
       connection,
     );
     await printer.writeln('Bold text', Style.Bold, Align.Center);
@@ -61,7 +61,7 @@ describe('print formatted text', () => {
   it('write text with double width and height', async () => {
     const connection = new InMemory();
     const printer = await Printer.connect(
-      new Model('TM-T20'),
+      await Model.initialise('TM-T20'),
       connection,
     );
     await printer.writeln(
@@ -77,7 +77,7 @@ describe('print formatted text', () => {
   it('write italic text', async () => {
     const connection = new InMemory();
     const printer = await Printer.connect(
-      new Model('TM-T20'),
+      await Model.initialise('TM-T20'),
       connection,
     );
     await printer.writeln('Italic Text', Style.Italic, Align.Center);
@@ -89,7 +89,7 @@ describe('print formatted text', () => {
   it('write underline text', async () => {
     const connection = new InMemory();
     const printer = await Printer.connect(
-      new Model('TM-T20'),
+      await Model.initialise('TM-T20'),
       connection,
     );
     await printer.writeln('Underline Text', Style.Underline, Align.Center);
@@ -101,7 +101,7 @@ describe('print formatted text', () => {
   it('write condensed text', async () => {
     const connection = new InMemory();
     const printer = await Printer.connect(
-      new Model('TM-T20'),
+      await Model.initialise('TM-T20'),
       connection,
     );
     await printer.writeln('Condensed Text', Style.Condensed, Align.Center);
@@ -113,7 +113,7 @@ describe('print formatted text', () => {
   it('draw qrcode', async () => {
     const connection = new InMemory();
     const printer = await Printer.connect(
-      new Model('MP-4200 TH'),
+      await Model.initialise('MP-4200 TH'),
       connection,
     );
     await printer.setAlignment(Align.Center);
@@ -127,7 +127,7 @@ describe('print formatted text', () => {
   it('emit buzzer', async () => {
     const connection = new InMemory();
     const printer = await Printer.connect(
-      new Model('TM-T20'),
+      await Model.initialise('TM-T20'),
       connection,
     );
     await printer.buzzer();
@@ -139,7 +139,7 @@ describe('print formatted text', () => {
   it('activate drawer', async () => {
     const connection = new InMemory();
     const printer = await Printer.connect(
-      new Model('TM-T20'),
+      await Model.initialise('TM-T20'),
       connection,
     );
     await printer.drawer();
@@ -151,7 +151,7 @@ describe('print formatted text', () => {
   it('cut paper', async () => {
     const connection = new InMemory();
     const printer = await Printer.connect(
-      new Model('TM-T20'),
+      await Model.initialise('TM-T20'),
       connection,
     );
     await printer.cutter();
@@ -163,7 +163,7 @@ describe('print formatted text', () => {
   it('draw picture from file', async () => {
     const connection = new InMemory();
     const printer = await Printer.connect(
-      new Model('MP-4200 TH'),
+      await Model.initialise('MP-4200 TH'),
       connection,
     );
     const image = new Image(path.join(__dirname, 'resources/sample.png'));
@@ -178,7 +178,7 @@ describe('print formatted text', () => {
   it('draw picture from buffer', async () => {
     const connection = new InMemory();
     const printer = await Printer.connect(
-      new Model('MP-4200 TH'),
+      await Model.initialise('MP-4200 TH'),
       connection,
     );
     const image = new Image(load('sample.png'));
@@ -219,35 +219,35 @@ describe('print formatted text', () => {
   it('check default columns', async () => {
     const connection = new InMemory();
     const printer = await Printer.connect(
-      new Model('MP-4200 TH'),
+      await Model.initialise('MP-4200 TH'),
       connection,
     );
     const capability = Model.ALL().find(
       ({ model }: Capability) => model == 'MP-4200 TH',
     );
-    expect(printer.setColumns).toBe(capability.columns);
+    expect(printer.columns).toBe(capability.columns);
   });
 
   it('change columns', async () => {
     const connection = new InMemory();
-    const model = new Model('MP-4200 TH');
+    const model = await Model.initialise('MP-4200 TH');
     const printer = await Printer.connect(model, connection);
-    printer.setColumns = 42;
+    await printer.setColumns(42);
     expect(model.profile.font.name).toBe('Font A');
   });
 
   it('overflow columns', async () => {
     const connection = new InMemory();
-    const model = new Model('MP-4200 TH');
+    const model = await Model.initialise('MP-4200 TH');
     const printer = await Printer.connect(model, connection);
-    printer.setColumns = 62;
+    await printer.setColumns(62);
     expect(model.profile.font.name).toBe('Font B');
-    expect(printer.setColumns).toBe(56);
+    expect(printer.columns).toBe(56);
   });
 
   it('change codepage', async () => {
     const connection = new InMemory();
-    const model = new Model('MP-4200 TH');
+    const model = await Model.initialise('MP-4200 TH');
     const printer = await Printer.connect(model, connection);
     await printer.setCodepage('utf8');
     await printer.writeln('Açênts');
@@ -257,26 +257,24 @@ describe('print formatted text', () => {
   });
 
   it('unsupported model', async () => {
-    expect(() => {
-      new Model('Unknow Model');
-    }).toThrow();
+    expect(Model.initialise('Unknow Model')).rejects.toThrow();
   });
 
   it('unsupported codepage', async () => {
     const connection = new InMemory();
-    const model = new Model('MP-4200 TH');
+    const model = await Model.initialise('MP-4200 TH');
     const printer = await Printer.connect(model, connection);
     expect(printer.setCodepage('utf9')).rejects.toThrow();
   });
 
   it('write without connection', async () => {
-    const model = new Model('MP-4200 TH');
+    const model = await Model.initialise('MP-4200 TH');
     await expect(model.profile.feed(1)).rejects.toThrow();
   });
 
   it('should forward withStyle to the profile', async () => {
     const connection = new InMemory();
-    const model = new Model('MP-4200 TH');
+    const model = await Model.initialise('MP-4200 TH');
     const withStyleSpy = jest
       .spyOn(model.profile, 'withStyle')
       .mockImplementation((_: StyleConf, cb: Function) => cb());

--- a/__tests__/Printer.spec.ts
+++ b/__tests__/Printer.spec.ts
@@ -11,7 +11,10 @@ import { load } from './helper';
 describe('print formatted text', () => {
   it('write text', async () => {
     const connection = new InMemory();
-    const printer = new Printer(new Model('TM-T20'), connection);
+    const printer = await Printer.connectPrinter(
+      new Model('TM-T20'),
+      connection,
+    );
     await printer.write('Simple Text');
     await printer.feed();
     expect(connection.buffer()).toStrictEqual(
@@ -21,7 +24,10 @@ describe('print formatted text', () => {
 
   it('write line', async () => {
     const connection = new InMemory();
-    const printer = new Printer(new Model('TM-T20'), connection);
+    const printer = await Printer.connectPrinter(
+      new Model('TM-T20'),
+      connection,
+    );
     await printer.writeln('Simple Line');
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_write_line', connection.buffer()),
@@ -30,7 +36,10 @@ describe('print formatted text', () => {
 
   it('write empty line', async () => {
     const connection = new InMemory();
-    const printer = new Printer(new Model('TM-T20'), connection);
+    const printer = await Printer.connectPrinter(
+      new Model('TM-T20'),
+      connection,
+    );
     await printer.writeln();
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_write_empty_line', connection.buffer()),
@@ -39,7 +48,10 @@ describe('print formatted text', () => {
 
   it('write bold text', async () => {
     const connection = new InMemory();
-    const printer = new Printer(new Model('TM-T20'), connection);
+    const printer = await Printer.connectPrinter(
+      new Model('TM-T20'),
+      connection,
+    );
     await printer.writeln('Bold text', Style.Bold, Align.Center);
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_bold_text', connection.buffer()),
@@ -48,7 +60,10 @@ describe('print formatted text', () => {
 
   it('write text with double width and height', async () => {
     const connection = new InMemory();
-    const printer = new Printer(new Model('TM-T20'), connection);
+    const printer = await Printer.connectPrinter(
+      new Model('TM-T20'),
+      connection,
+    );
     await printer.writeln(
       'Large Text',
       Style.DoubleWidth + Style.DoubleHeight,
@@ -61,7 +76,10 @@ describe('print formatted text', () => {
 
   it('write italic text', async () => {
     const connection = new InMemory();
-    const printer = new Printer(new Model('TM-T20'), connection);
+    const printer = await Printer.connectPrinter(
+      new Model('TM-T20'),
+      connection,
+    );
     await printer.writeln('Italic Text', Style.Italic, Align.Center);
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_italic_text', connection.buffer()),
@@ -70,7 +88,10 @@ describe('print formatted text', () => {
 
   it('write underline text', async () => {
     const connection = new InMemory();
-    const printer = new Printer(new Model('TM-T20'), connection);
+    const printer = await Printer.connectPrinter(
+      new Model('TM-T20'),
+      connection,
+    );
     await printer.writeln('Underline Text', Style.Underline, Align.Center);
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_underline_text', connection.buffer()),
@@ -79,7 +100,10 @@ describe('print formatted text', () => {
 
   it('write condensed text', async () => {
     const connection = new InMemory();
-    const printer = new Printer(new Model('TM-T20'), connection);
+    const printer = await Printer.connectPrinter(
+      new Model('TM-T20'),
+      connection,
+    );
     await printer.writeln('Condensed Text', Style.Condensed, Align.Center);
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_condensed_text', connection.buffer()),
@@ -88,7 +112,10 @@ describe('print formatted text', () => {
 
   it('draw qrcode', async () => {
     const connection = new InMemory();
-    const printer = new Printer(new Model('MP-4200 TH'), connection);
+    const printer = await Printer.connectPrinter(
+      new Model('MP-4200 TH'),
+      connection,
+    );
     printer.alignment = Align.Center;
     await printer.qrcode('https://github.com/grandchef/escpos-buffer');
     printer.alignment = Align.Left;
@@ -99,7 +126,10 @@ describe('print formatted text', () => {
 
   it('emit buzzer', async () => {
     const connection = new InMemory();
-    const printer = new Printer(new Model('TM-T20'), connection);
+    const printer = await Printer.connectPrinter(
+      new Model('TM-T20'),
+      connection,
+    );
     await printer.buzzer();
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_buzzer', connection.buffer()),
@@ -108,7 +138,10 @@ describe('print formatted text', () => {
 
   it('activate drawer', async () => {
     const connection = new InMemory();
-    const printer = new Printer(new Model('TM-T20'), connection);
+    const printer = await Printer.connectPrinter(
+      new Model('TM-T20'),
+      connection,
+    );
     await printer.drawer();
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_drawer', connection.buffer()),
@@ -117,7 +150,10 @@ describe('print formatted text', () => {
 
   it('cut paper', async () => {
     const connection = new InMemory();
-    const printer = new Printer(new Model('TM-T20'), connection);
+    const printer = await Printer.connectPrinter(
+      new Model('TM-T20'),
+      connection,
+    );
     await printer.cutter();
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_cut', connection.buffer()),
@@ -126,7 +162,10 @@ describe('print formatted text', () => {
 
   it('draw picture from file', async () => {
     const connection = new InMemory();
-    const printer = new Printer(new Model('MP-4200 TH'), connection);
+    const printer = await Printer.connectPrinter(
+      new Model('MP-4200 TH'),
+      connection,
+    );
     const image = new Image(path.join(__dirname, 'resources/sample.png'));
     printer.alignment = Align.Center;
     await printer.draw(image);
@@ -138,7 +177,10 @@ describe('print formatted text', () => {
 
   it('draw picture from buffer', async () => {
     const connection = new InMemory();
-    const printer = new Printer(new Model('MP-4200 TH'), connection);
+    const printer = await Printer.connectPrinter(
+      new Model('MP-4200 TH'),
+      connection,
+    );
     const image = new Image(load('sample.png'));
     printer.alignment = Align.Center;
     await printer.draw(image);
@@ -176,7 +218,10 @@ describe('print formatted text', () => {
 
   it('check default columns', async () => {
     const connection = new InMemory();
-    const printer = new Printer(new Model('MP-4200 TH'), connection);
+    const printer = await Printer.connectPrinter(
+      new Model('MP-4200 TH'),
+      connection,
+    );
     const capability = Model.ALL().find(
       ({ model }: Capability) => model == 'MP-4200 TH',
     );
@@ -186,7 +231,7 @@ describe('print formatted text', () => {
   it('change columns', async () => {
     const connection = new InMemory();
     const model = new Model('MP-4200 TH');
-    const printer = new Printer(model, connection);
+    const printer = await Printer.connectPrinter(model, connection);
     printer.columns = 42;
     expect(model.profile.font.name).toBe('Font A');
   });
@@ -194,13 +239,13 @@ describe('print formatted text', () => {
   it('overflow columns', async () => {
     const connection = new InMemory();
     const model = new Model('MP-4200 TH');
-    const printer = new Printer(model, connection);
+    const printer = await Printer.connectPrinter(model, connection);
     printer.columns = 62;
     expect(model.profile.font.name).toBe('Font B');
     expect(printer.columns).toBe(56);
   });
 
-  it.only('change codepage', async () => {
+  it('change codepage', async () => {
     const connection = new InMemory();
     const model = new Model('MP-4200 TH');
     const printer = await Printer.connectPrinter(model, connection);
@@ -218,12 +263,10 @@ describe('print formatted text', () => {
   });
 
   it('unsupported codepage', async () => {
-    expect(() => {
-      const connection = new InMemory();
-      const model = new Model('MP-4200 TH');
-      const printer = new Printer(model, connection);
-      printer.codepage = 'utf9';
-    }).toThrow();
+    const connection = new InMemory();
+    const model = new Model('MP-4200 TH');
+    const printer = await Printer.connectPrinter(model, connection);
+    expect(printer.setCodepage('utf9')).rejects.toThrow();
   });
 
   it('write without connection', async () => {
@@ -237,7 +280,7 @@ describe('print formatted text', () => {
     const withStyleSpy = jest
       .spyOn(model.profile, 'withStyle')
       .mockImplementation((_: StyleConf, cb: Function) => cb());
-    const printer = new Printer(model, connection);
+    const printer = await Printer.connectPrinter(model, connection);
 
     const styleConf = {
       width: 4,

--- a/__tests__/Printer.spec.ts
+++ b/__tests__/Printer.spec.ts
@@ -116,9 +116,9 @@ describe('print formatted text', () => {
       new Model('MP-4200 TH'),
       connection,
     );
-    printer.alignment = Align.Center;
+    await printer.setAlignment(Align.Center);
     await printer.qrcode('https://github.com/grandchef/escpos-buffer');
-    printer.alignment = Align.Left;
+    await printer.setAlignment(Align.Left);
     expect(connection.buffer()).toStrictEqual(
       load('mp-4200_th_qrcode', connection.buffer()),
     );
@@ -167,9 +167,9 @@ describe('print formatted text', () => {
       connection,
     );
     const image = new Image(path.join(__dirname, 'resources/sample.png'));
-    printer.alignment = Align.Center;
+    await printer.setAlignment(Align.Center);
     await printer.draw(image);
-    printer.alignment = Align.Left;
+    await printer.setAlignment(Align.Left);
     expect(connection.buffer()).toStrictEqual(
       load('mp-4200_th_draw_file', connection.buffer()),
     );
@@ -182,9 +182,9 @@ describe('print formatted text', () => {
       connection,
     );
     const image = new Image(load('sample.png'));
-    printer.alignment = Align.Center;
+    await printer.setAlignment(Align.Center);
     await printer.draw(image);
-    printer.alignment = Align.Left;
+    await printer.setAlignment(Align.Left);
     await printer.close();
     expect(connection.buffer()).toStrictEqual(
       load('mp-4200_th_draw_buffer', connection.buffer()),

--- a/__tests__/Printer.spec.ts
+++ b/__tests__/Printer.spec.ts
@@ -227,10 +227,8 @@ describe('print formatted text', () => {
   });
 
   it('write without connection', async () => {
-    expect(() => {
-      const model = new Model('MP-4200 TH');
-      model.profile.feed(1);
-    }).toThrow();
+    const model = new Model('MP-4200 TH');
+    await expect(model.profile.feed(1)).rejects.toThrow();
   });
 
   it('should forward withStyle to the profile', () => {

--- a/__tests__/Printer.spec.ts
+++ b/__tests__/Printer.spec.ts
@@ -11,7 +11,7 @@ import { load } from './helper';
 describe('print formatted text', () => {
   it('write text', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connectPrinter(
+    const printer = await Printer.connect(
       new Model('TM-T20'),
       connection,
     );
@@ -24,7 +24,7 @@ describe('print formatted text', () => {
 
   it('write line', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connectPrinter(
+    const printer = await Printer.connect(
       new Model('TM-T20'),
       connection,
     );
@@ -36,7 +36,7 @@ describe('print formatted text', () => {
 
   it('write empty line', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connectPrinter(
+    const printer = await Printer.connect(
       new Model('TM-T20'),
       connection,
     );
@@ -48,7 +48,7 @@ describe('print formatted text', () => {
 
   it('write bold text', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connectPrinter(
+    const printer = await Printer.connect(
       new Model('TM-T20'),
       connection,
     );
@@ -60,7 +60,7 @@ describe('print formatted text', () => {
 
   it('write text with double width and height', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connectPrinter(
+    const printer = await Printer.connect(
       new Model('TM-T20'),
       connection,
     );
@@ -76,7 +76,7 @@ describe('print formatted text', () => {
 
   it('write italic text', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connectPrinter(
+    const printer = await Printer.connect(
       new Model('TM-T20'),
       connection,
     );
@@ -88,7 +88,7 @@ describe('print formatted text', () => {
 
   it('write underline text', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connectPrinter(
+    const printer = await Printer.connect(
       new Model('TM-T20'),
       connection,
     );
@@ -100,7 +100,7 @@ describe('print formatted text', () => {
 
   it('write condensed text', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connectPrinter(
+    const printer = await Printer.connect(
       new Model('TM-T20'),
       connection,
     );
@@ -112,7 +112,7 @@ describe('print formatted text', () => {
 
   it('draw qrcode', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connectPrinter(
+    const printer = await Printer.connect(
       new Model('MP-4200 TH'),
       connection,
     );
@@ -126,7 +126,7 @@ describe('print formatted text', () => {
 
   it('emit buzzer', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connectPrinter(
+    const printer = await Printer.connect(
       new Model('TM-T20'),
       connection,
     );
@@ -138,7 +138,7 @@ describe('print formatted text', () => {
 
   it('activate drawer', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connectPrinter(
+    const printer = await Printer.connect(
       new Model('TM-T20'),
       connection,
     );
@@ -150,7 +150,7 @@ describe('print formatted text', () => {
 
   it('cut paper', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connectPrinter(
+    const printer = await Printer.connect(
       new Model('TM-T20'),
       connection,
     );
@@ -162,7 +162,7 @@ describe('print formatted text', () => {
 
   it('draw picture from file', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connectPrinter(
+    const printer = await Printer.connect(
       new Model('MP-4200 TH'),
       connection,
     );
@@ -177,7 +177,7 @@ describe('print formatted text', () => {
 
   it('draw picture from buffer', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connectPrinter(
+    const printer = await Printer.connect(
       new Model('MP-4200 TH'),
       connection,
     );
@@ -218,7 +218,7 @@ describe('print formatted text', () => {
 
   it('check default columns', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connectPrinter(
+    const printer = await Printer.connect(
       new Model('MP-4200 TH'),
       connection,
     );
@@ -231,7 +231,7 @@ describe('print formatted text', () => {
   it('change columns', async () => {
     const connection = new InMemory();
     const model = new Model('MP-4200 TH');
-    const printer = await Printer.connectPrinter(model, connection);
+    const printer = await Printer.connect(model, connection);
     printer.setColumns = 42;
     expect(model.profile.font.name).toBe('Font A');
   });
@@ -239,7 +239,7 @@ describe('print formatted text', () => {
   it('overflow columns', async () => {
     const connection = new InMemory();
     const model = new Model('MP-4200 TH');
-    const printer = await Printer.connectPrinter(model, connection);
+    const printer = await Printer.connect(model, connection);
     printer.setColumns = 62;
     expect(model.profile.font.name).toBe('Font B');
     expect(printer.setColumns).toBe(56);
@@ -248,7 +248,7 @@ describe('print formatted text', () => {
   it('change codepage', async () => {
     const connection = new InMemory();
     const model = new Model('MP-4200 TH');
-    const printer = await Printer.connectPrinter(model, connection);
+    const printer = await Printer.connect(model, connection);
     await printer.setCodepage('utf8');
     await printer.writeln('Açênts');
     expect(connection.buffer()).toStrictEqual(
@@ -265,7 +265,7 @@ describe('print formatted text', () => {
   it('unsupported codepage', async () => {
     const connection = new InMemory();
     const model = new Model('MP-4200 TH');
-    const printer = await Printer.connectPrinter(model, connection);
+    const printer = await Printer.connect(model, connection);
     expect(printer.setCodepage('utf9')).rejects.toThrow();
   });
 
@@ -280,7 +280,7 @@ describe('print formatted text', () => {
     const withStyleSpy = jest
       .spyOn(model.profile, 'withStyle')
       .mockImplementation((_: StyleConf, cb: Function) => cb());
-    const printer = await Printer.connectPrinter(model, connection);
+    const printer = await Printer.connect(model, connection);
 
     const styleConf = {
       width: 4,

--- a/__tests__/Printer.spec.ts
+++ b/__tests__/Printer.spec.ts
@@ -203,8 +203,8 @@ describe('print formatted text', () => {
   it.only('change codepage', async () => {
     const connection = new InMemory();
     const model = new Model('MP-4200 TH');
-    const printer = new Printer(model, connection);
-    printer.codepage = 'utf8';
+    const printer = await Printer.connectPrinter(model, connection);
+    await printer.setCodepage('utf8');
     await printer.writeln('Açênts');
     expect(connection.buffer()).toStrictEqual(
       load('mp-4200_th_utf8_text', connection.buffer()),

--- a/__tests__/Printer.spec.ts
+++ b/__tests__/Printer.spec.ts
@@ -4,7 +4,7 @@ import { Capability } from '../src/capabilities';
 import InMemory from '../src/connection/InMemory';
 import Model from '../src/Model';
 import Printer, { Align, Style } from '../src/Printer';
-import { StyleConf } from '../src/profile';
+import { StyleConf, Profile } from '../src/profile';
 import Elgin from '../src/profile/Elgin';
 import { load } from './helper';
 
@@ -211,7 +211,7 @@ describe('print formatted text', () => {
         },
       ],
     };
-    const profile = new Elgin(capability);
+    const profile = await Profile.initialise(Elgin,capability);
     const model = new Model(profile);
     expect(model.profile.font.name).toBe('Font A');
   });

--- a/__tests__/Printer.spec.ts
+++ b/__tests__/Printer.spec.ts
@@ -9,47 +9,47 @@ import Elgin from '../src/profile/Elgin';
 import { load } from './helper';
 
 describe('print formatted text', () => {
-  it('write text', () => {
+  it('write text', async () => {
     const connection = new InMemory();
     const printer = new Printer(new Model('TM-T20'), connection);
-    printer.write('Simple Text');
-    printer.feed();
+    await printer.write('Simple Text');
+    await printer.feed();
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_write_text', connection.buffer()),
     );
   });
 
-  it('write line', () => {
+  it('write line', async () => {
     const connection = new InMemory();
     const printer = new Printer(new Model('TM-T20'), connection);
-    printer.writeln('Simple Line');
+    await printer.writeln('Simple Line');
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_write_line', connection.buffer()),
     );
   });
 
-  it('write empty line', () => {
+  it('write empty line', async () => {
     const connection = new InMemory();
     const printer = new Printer(new Model('TM-T20'), connection);
-    printer.writeln();
+    await printer.writeln();
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_write_empty_line', connection.buffer()),
     );
   });
 
-  it('write bold text', () => {
+  it('write bold text', async () => {
     const connection = new InMemory();
     const printer = new Printer(new Model('TM-T20'), connection);
-    printer.writeln('Bold text', Style.Bold, Align.Center);
+    await printer.writeln('Bold text', Style.Bold, Align.Center);
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_bold_text', connection.buffer()),
     );
   });
 
-  it('write text with double width and height', () => {
+  it('write text with double width and height', async () => {
     const connection = new InMemory();
     const printer = new Printer(new Model('TM-T20'), connection);
-    printer.writeln(
+    await printer.writeln(
       'Large Text',
       Style.DoubleWidth + Style.DoubleHeight,
       Align.Center,
@@ -59,28 +59,28 @@ describe('print formatted text', () => {
     );
   });
 
-  it('write italic text', () => {
+  it('write italic text', async () => {
     const connection = new InMemory();
     const printer = new Printer(new Model('TM-T20'), connection);
-    printer.writeln('Italic Text', Style.Italic, Align.Center);
+    await printer.writeln('Italic Text', Style.Italic, Align.Center);
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_italic_text', connection.buffer()),
     );
   });
 
-  it('write underline text', () => {
+  it('write underline text', async () => {
     const connection = new InMemory();
     const printer = new Printer(new Model('TM-T20'), connection);
-    printer.writeln('Underline Text', Style.Underline, Align.Center);
+    await printer.writeln('Underline Text', Style.Underline, Align.Center);
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_underline_text', connection.buffer()),
     );
   });
 
-  it('write condensed text', () => {
+  it('write condensed text', async () => {
     const connection = new InMemory();
     const printer = new Printer(new Model('TM-T20'), connection);
-    printer.writeln('Condensed Text', Style.Condensed, Align.Center);
+    await printer.writeln('Condensed Text', Style.Condensed, Align.Center);
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_condensed_text', connection.buffer()),
     );
@@ -100,7 +100,7 @@ describe('print formatted text', () => {
   it('emit buzzer', async () => {
     const connection = new InMemory();
     const printer = new Printer(new Model('TM-T20'), connection);
-    printer.buzzer();
+    await printer.buzzer();
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_buzzer', connection.buffer()),
     );
@@ -109,7 +109,7 @@ describe('print formatted text', () => {
   it('activate drawer', async () => {
     const connection = new InMemory();
     const printer = new Printer(new Model('TM-T20'), connection);
-    printer.drawer();
+    await printer.drawer();
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_drawer', connection.buffer()),
     );
@@ -118,7 +118,7 @@ describe('print formatted text', () => {
   it('cut paper', async () => {
     const connection = new InMemory();
     const printer = new Printer(new Model('TM-T20'), connection);
-    printer.cutter();
+    await printer.cutter();
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_cut', connection.buffer()),
     );
@@ -129,7 +129,7 @@ describe('print formatted text', () => {
     const printer = new Printer(new Model('MP-4200 TH'), connection);
     const image = new Image(path.join(__dirname, 'resources/sample.png'));
     printer.alignment = Align.Center;
-    printer.draw(image);
+    await printer.draw(image);
     printer.alignment = Align.Left;
     expect(connection.buffer()).toStrictEqual(
       load('mp-4200_th_draw_file', connection.buffer()),
@@ -141,9 +141,9 @@ describe('print formatted text', () => {
     const printer = new Printer(new Model('MP-4200 TH'), connection);
     const image = new Image(load('sample.png'));
     printer.alignment = Align.Center;
-    printer.draw(image);
+    await printer.draw(image);
     printer.alignment = Align.Left;
-    printer.close();
+    await printer.close();
     expect(connection.buffer()).toStrictEqual(
       load('mp-4200_th_draw_buffer', connection.buffer()),
     );
@@ -200,12 +200,12 @@ describe('print formatted text', () => {
     expect(printer.columns).toBe(56);
   });
 
-  it('change codepage', async () => {
+  it.only('change codepage', async () => {
     const connection = new InMemory();
     const model = new Model('MP-4200 TH');
     const printer = new Printer(model, connection);
     printer.codepage = 'utf8';
-    printer.writeln('Açênts');
+    await printer.writeln('Açênts');
     expect(connection.buffer()).toStrictEqual(
       load('mp-4200_th_utf8_text', connection.buffer()),
     );
@@ -231,7 +231,7 @@ describe('print formatted text', () => {
     await expect(model.profile.feed(1)).rejects.toThrow();
   });
 
-  it('should forward withStyle to the profile', () => {
+  it('should forward withStyle to the profile', async () => {
     const connection = new InMemory();
     const model = new Model('MP-4200 TH');
     const withStyleSpy = jest
@@ -244,7 +244,7 @@ describe('print formatted text', () => {
       height: 8,
     };
     const cb = jest.fn();
-    printer.withStyle(styleConf, cb);
+    await printer.withStyle(styleConf, cb);
 
     expect(withStyleSpy).toHaveBeenCalledWith(styleConf, cb);
     expect(cb).toHaveBeenCalledTimes(1);

--- a/__tests__/Printer.spec.ts
+++ b/__tests__/Printer.spec.ts
@@ -13,7 +13,7 @@ import { load } from './helper';
 describe('print formatted text', () => {
   it('write text', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('TM-T20', connection);
+    const printer = await Printer.CONNECT('TM-T20', connection);
     await printer.write('Simple Text');
     await printer.feed();
     expect(connection.buffer()).toStrictEqual(
@@ -23,7 +23,7 @@ describe('print formatted text', () => {
 
   it('write line', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('TM-T20', connection);
+    const printer = await Printer.CONNECT('TM-T20', connection);
     await printer.writeln('Simple Line');
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_write_line', connection.buffer()),
@@ -32,7 +32,7 @@ describe('print formatted text', () => {
 
   it('write empty line', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('TM-T20', connection);
+    const printer = await Printer.CONNECT('TM-T20', connection);
     await printer.writeln();
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_write_empty_line', connection.buffer()),
@@ -41,7 +41,7 @@ describe('print formatted text', () => {
 
   it('write bold text', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('TM-T20', connection);
+    const printer = await Printer.CONNECT('TM-T20', connection);
     await printer.writeln('Bold text', Style.Bold, Align.Center);
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_bold_text', connection.buffer()),
@@ -50,7 +50,7 @@ describe('print formatted text', () => {
 
   it('write text with double width and height', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('TM-T20', connection);
+    const printer = await Printer.CONNECT('TM-T20', connection);
     await printer.writeln(
       'Large Text',
       Style.DoubleWidth + Style.DoubleHeight,
@@ -63,7 +63,7 @@ describe('print formatted text', () => {
 
   it('write italic text', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('TM-T20', connection);
+    const printer = await Printer.CONNECT('TM-T20', connection);
     await printer.writeln('Italic Text', Style.Italic, Align.Center);
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_italic_text', connection.buffer()),
@@ -72,7 +72,7 @@ describe('print formatted text', () => {
 
   it('write underline text', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('TM-T20', connection);
+    const printer = await Printer.CONNECT('TM-T20', connection);
     await printer.writeln('Underline Text', Style.Underline, Align.Center);
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_underline_text', connection.buffer()),
@@ -81,7 +81,7 @@ describe('print formatted text', () => {
 
   it('write condensed text', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('TM-T20', connection);
+    const printer = await Printer.CONNECT('TM-T20', connection);
     await printer.writeln('Condensed Text', Style.Condensed, Align.Center);
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_condensed_text', connection.buffer()),
@@ -90,7 +90,7 @@ describe('print formatted text', () => {
 
   it('draw qrcode', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('MP-4200 TH', connection);
+    const printer = await Printer.CONNECT('MP-4200 TH', connection);
     await printer.setAlignment(Align.Center);
     await printer.qrcode('https://github.com/grandchef/escpos-buffer');
     await printer.setAlignment(Align.Left);
@@ -101,7 +101,7 @@ describe('print formatted text', () => {
 
   it('emit buzzer', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('TM-T20', connection);
+    const printer = await Printer.CONNECT('TM-T20', connection);
     await printer.buzzer();
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_buzzer', connection.buffer()),
@@ -110,7 +110,7 @@ describe('print formatted text', () => {
 
   it('activate drawer', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('TM-T20', connection);
+    const printer = await Printer.CONNECT('TM-T20', connection);
     await printer.drawer();
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_drawer', connection.buffer()),
@@ -119,7 +119,7 @@ describe('print formatted text', () => {
 
   it('cut paper', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('TM-T20', connection);
+    const printer = await Printer.CONNECT('TM-T20', connection);
     await printer.cutter();
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_cut', connection.buffer()),
@@ -128,7 +128,7 @@ describe('print formatted text', () => {
 
   it('draw picture from file', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('MP-4200 TH', connection);
+    const printer = await Printer.CONNECT('MP-4200 TH', connection);
     const image = new Image(path.join(__dirname, 'resources/sample.png'));
     await printer.setAlignment(Align.Center);
     await printer.draw(image);
@@ -140,7 +140,7 @@ describe('print formatted text', () => {
 
   it('draw picture from buffer', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('MP-4200 TH', connection);
+    const printer = await Printer.CONNECT('MP-4200 TH', connection);
     const image = new Image(load('sample.png'));
     await printer.setAlignment(Align.Center);
     await printer.draw(image);
@@ -173,13 +173,13 @@ describe('print formatted text', () => {
     };
     const profile = new Elgin(capability);
     const model = new Model(profile);
-    await Printer.connect(model, new InMemory());
+    await Printer.CONNECT(model, new InMemory());
     expect(model.profile.font.name).toBe('Font A');
   });
 
   it('check default columns', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('MP-4200 TH', connection);
+    const printer = await Printer.CONNECT('MP-4200 TH', connection);
     const capability = Model.ALL().find(
       ({ model }: Capability) => model == 'MP-4200 TH',
     );
@@ -204,7 +204,7 @@ describe('print formatted text', () => {
   it('change codepage', async () => {
     const connection = new InMemory();
     const model = 'MP-4200 TH';
-    const printer = await Printer.connect(model, connection);
+    const printer = await Printer.CONNECT(model, connection);
     await printer.setCodepage('utf8');
     await printer.writeln('Açênts');
     expect(connection.buffer()).toStrictEqual(

--- a/__tests__/graphics/filter/BayerOrdered.spec.ts
+++ b/__tests__/graphics/filter/BayerOrdered.spec.ts
@@ -1,9 +1,9 @@
-import { load } from '../../helper'
-import { BayerOrdered, Image } from '../../../src'
+import { load } from '../../helper';
+import { BayerOrdered, Image } from '../../../src';
 
 describe('proccess images using Bayer ordered algorithm', () => {
   it('apply filter on image from buffer', () => {
-    const image = new Image(load('sample.png'), new BayerOrdered())
-    expect(image.data).toStrictEqual(load('bayer_filter', image.data))
-  })
-})
+    const image = new Image(load('sample.png'), new BayerOrdered());
+    expect(image.data).toStrictEqual(load('bayer_filter', image.data));
+  });
+});

--- a/__tests__/graphics/filter/FloydSteinberg.spec.ts
+++ b/__tests__/graphics/filter/FloydSteinberg.spec.ts
@@ -1,9 +1,11 @@
-import { load } from '../../helper'
-import { FloydSteinberg, Image } from '../../../src'
+import { load } from '../../helper';
+import { FloydSteinberg, Image } from '../../../src';
 
 describe('proccess images using Floyd and Steinberg algorithm', () => {
   it('apply filter on image from buffer', () => {
-    const image = new Image(load('sample.png'), new FloydSteinberg())
-    expect(image.data).toStrictEqual(load('floyd_steinberg_filter', image.data))
-  })
-})
+    const image = new Image(load('sample.png'), new FloydSteinberg());
+    expect(image.data).toStrictEqual(
+      load('floyd_steinberg_filter', image.data),
+    );
+  });
+});

--- a/__tests__/graphics/filter/Threshold.spec.ts
+++ b/__tests__/graphics/filter/Threshold.spec.ts
@@ -1,9 +1,9 @@
-import { load } from '../../helper'
-import { Threshold, Image } from '../../../src'
+import { load } from '../../helper';
+import { Threshold, Image } from '../../../src';
 
 describe('proccess images using threshold algorithm', () => {
   it('apply filter on image from buffer', () => {
-    const image = new Image(load('sample.png'), new Threshold())
-    expect(image.data).toStrictEqual(load('threshold_filter', image.data))
-  })
-})
+    const image = new Image(load('sample.png'), new Threshold());
+    expect(image.data).toStrictEqual(load('threshold_filter', image.data));
+  });
+});

--- a/__tests__/profile/Bematech.spec.ts
+++ b/__tests__/profile/Bematech.spec.ts
@@ -6,7 +6,7 @@ import { load } from '../helper';
 describe('bematech model profile', () => {
   it('write bold text from model MP-4200 TH', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connectPrinter(
+    const printer = await Printer.connect(
       await Model.initialise('MP-4200 TH'),
       connection,
     );
@@ -21,7 +21,7 @@ describe('bematech model profile', () => {
 
   it('write bold text on another font from model MP-4200 TH', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connectPrinter(
+    const printer = await Printer.connect(
       await Model.initialise('MP-4200 TH'),
       connection,
     );
@@ -34,7 +34,7 @@ describe('bematech model profile', () => {
 
   it('write text with double width and height from model MP-4200 TH', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connectPrinter(
+    const printer = await Printer.connect(
       await Model.initialise('MP-4200 TH'),
       connection,
     );
@@ -50,7 +50,7 @@ describe('bematech model profile', () => {
 
   it('draw qrcode from model MP-4200 TH', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connectPrinter(
+    const printer = await Printer.connect(
       await Model.initialise('MP-4200 TH'),
       connection,
     );
@@ -64,7 +64,7 @@ describe('bematech model profile', () => {
 
   it('emit buzzer from model MP-4200 TH', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connectPrinter(
+    const printer = await Printer.connect(
       await Model.initialise('MP-4200 TH'),
       connection,
     );
@@ -76,7 +76,7 @@ describe('bematech model profile', () => {
 
   it('emit buzzer from model MP-2800 TH', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connectPrinter(
+    const printer = await Printer.connect(
       await Model.initialise('MP-2800 TH'),
       connection,
     );
@@ -88,7 +88,7 @@ describe('bematech model profile', () => {
 
   it('emit buzzer on another font from model MP-4200 TH', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connectPrinter(
+    const printer = await Printer.connect(
       await Model.initialise('MP-4200 TH'),
       connection,
     );
@@ -101,7 +101,7 @@ describe('bematech model profile', () => {
 
   it('activate drawer from model MP-4200 TH', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connectPrinter(
+    const printer = await Printer.connect(
       await Model.initialise('MP-4200 TH'),
       connection,
     );
@@ -113,7 +113,7 @@ describe('bematech model profile', () => {
 
   it('activate drawer on another font from model MP-4200 TH', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connectPrinter(
+    const printer = await Printer.connect(
       await Model.initialise('MP-4200 TH'),
       connection,
     );

--- a/__tests__/profile/Bematech.spec.ts
+++ b/__tests__/profile/Bematech.spec.ts
@@ -7,7 +7,7 @@ import { load } from '../helper';
 describe('bematech model profile', () => {
   it('write bold text from model MP-4200 TH', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('MP-4200 TH', connection);
+    const printer = await Printer.CONNECT('MP-4200 TH', connection);
     await printer.setColumns(42);
     await printer.writeln('Bold text', Style.Bold, Align.Center);
     await printer.setColumns(50);
@@ -19,7 +19,7 @@ describe('bematech model profile', () => {
 
   it('write bold text on another font from model MP-4200 TH', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('MP-4200 TH', connection);
+    const printer = await Printer.CONNECT('MP-4200 TH', connection);
     await printer.setColumns(42);
     await printer.writeln('Bold text', Style.Bold, Align.Center);
     expect(connection.buffer()).toStrictEqual(
@@ -29,7 +29,7 @@ describe('bematech model profile', () => {
 
   it('write text with double width and height from model MP-4200 TH', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('MP-4200 TH', connection);
+    const printer = await Printer.CONNECT('MP-4200 TH', connection);
     await printer.writeln(
       'Large Text',
       Style.DoubleWidth + Style.DoubleHeight,
@@ -42,7 +42,7 @@ describe('bematech model profile', () => {
 
   it('draw qrcode from model MP-4200 TH', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('MP-4200 TH', connection);
+    const printer = await Printer.CONNECT('MP-4200 TH', connection);
     await printer.setAlignment(Align.Center);
     await printer.qrcode('https://github.com/grandchef/escpos-buffer');
     await printer.setAlignment(Align.Left);
@@ -53,7 +53,7 @@ describe('bematech model profile', () => {
 
   it('emit buzzer from model MP-4200 TH', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('MP-4200 TH', connection);
+    const printer = await Printer.CONNECT('MP-4200 TH', connection);
     printer.buzzer();
     expect(connection.buffer()).toStrictEqual(
       load('mp-4200_th_buzzer', connection.buffer()),
@@ -62,7 +62,7 @@ describe('bematech model profile', () => {
 
   it('emit buzzer from model MP-2800 TH', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('MP-2800 TH', connection);
+    const printer = await Printer.CONNECT('MP-2800 TH', connection);
     printer.buzzer();
     expect(connection.buffer()).toStrictEqual(
       load('mp-2800_th_buzzer', connection.buffer()),
@@ -71,7 +71,7 @@ describe('bematech model profile', () => {
 
   it('emit buzzer on another font from model MP-4200 TH', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('MP-4200 TH', connection);
+    const printer = await Printer.CONNECT('MP-4200 TH', connection);
     await printer.setColumns(42);
     printer.buzzer();
     expect(connection.buffer()).toStrictEqual(
@@ -81,7 +81,7 @@ describe('bematech model profile', () => {
 
   it('activate drawer from model MP-4200 TH', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('MP-4200 TH', connection);
+    const printer = await Printer.CONNECT('MP-4200 TH', connection);
     printer.drawer();
     expect(connection.buffer()).toStrictEqual(
       load('mp-4200_th_drawer', connection.buffer()),
@@ -90,7 +90,7 @@ describe('bematech model profile', () => {
 
   it('activate drawer on another font from model MP-4200 TH', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('MP-4200 TH', connection);
+    const printer = await Printer.CONNECT('MP-4200 TH', connection);
     await printer.setColumns(42);
     printer.drawer();
     expect(connection.buffer()).toStrictEqual(

--- a/__tests__/profile/Bematech.spec.ts
+++ b/__tests__/profile/Bematech.spec.ts
@@ -1,17 +1,13 @@
-import Model from '../../src/Model';
 import InMemory from '../../src/connection/InMemory';
 import Printer from '../../src/Printer';
-import {Align} from "../../src/Align";
-import {Style} from "../../src/Style";
+import { Align } from '../../src/Align';
+import { Style } from '../../src/Style';
 import { load } from '../helper';
 
 describe('bematech model profile', () => {
   it('write bold text from model MP-4200 TH', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('MP-4200 TH'),
-      connection,
-    );
+    const printer = await Printer.connect('MP-4200 TH', connection);
     await printer.setColumns(42);
     await printer.writeln('Bold text', Style.Bold, Align.Center);
     await printer.setColumns(50);
@@ -23,10 +19,7 @@ describe('bematech model profile', () => {
 
   it('write bold text on another font from model MP-4200 TH', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('MP-4200 TH'),
-      connection,
-    );
+    const printer = await Printer.connect('MP-4200 TH', connection);
     await printer.setColumns(42);
     await printer.writeln('Bold text', Style.Bold, Align.Center);
     expect(connection.buffer()).toStrictEqual(
@@ -36,10 +29,7 @@ describe('bematech model profile', () => {
 
   it('write text with double width and height from model MP-4200 TH', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('MP-4200 TH'),
-      connection,
-    );
+    const printer = await Printer.connect('MP-4200 TH', connection);
     await printer.writeln(
       'Large Text',
       Style.DoubleWidth + Style.DoubleHeight,
@@ -52,10 +42,7 @@ describe('bematech model profile', () => {
 
   it('draw qrcode from model MP-4200 TH', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('MP-4200 TH'),
-      connection,
-    );
+    const printer = await Printer.connect('MP-4200 TH', connection);
     await printer.setAlignment(Align.Center);
     await printer.qrcode('https://github.com/grandchef/escpos-buffer');
     await printer.setAlignment(Align.Left);
@@ -66,10 +53,7 @@ describe('bematech model profile', () => {
 
   it('emit buzzer from model MP-4200 TH', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('MP-4200 TH'),
-      connection,
-    );
+    const printer = await Printer.connect('MP-4200 TH', connection);
     printer.buzzer();
     expect(connection.buffer()).toStrictEqual(
       load('mp-4200_th_buzzer', connection.buffer()),
@@ -78,10 +62,7 @@ describe('bematech model profile', () => {
 
   it('emit buzzer from model MP-2800 TH', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('MP-2800 TH'),
-      connection,
-    );
+    const printer = await Printer.connect('MP-2800 TH', connection);
     printer.buzzer();
     expect(connection.buffer()).toStrictEqual(
       load('mp-2800_th_buzzer', connection.buffer()),
@@ -90,10 +71,7 @@ describe('bematech model profile', () => {
 
   it('emit buzzer on another font from model MP-4200 TH', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('MP-4200 TH'),
-      connection,
-    );
+    const printer = await Printer.connect('MP-4200 TH', connection);
     await printer.setColumns(42);
     printer.buzzer();
     expect(connection.buffer()).toStrictEqual(
@@ -103,10 +81,7 @@ describe('bematech model profile', () => {
 
   it('activate drawer from model MP-4200 TH', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('MP-4200 TH'),
-      connection,
-    );
+    const printer = await Printer.connect('MP-4200 TH', connection);
     printer.drawer();
     expect(connection.buffer()).toStrictEqual(
       load('mp-4200_th_drawer', connection.buffer()),
@@ -115,10 +90,7 @@ describe('bematech model profile', () => {
 
   it('activate drawer on another font from model MP-4200 TH', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('MP-4200 TH'),
-      connection,
-    );
+    const printer = await Printer.connect('MP-4200 TH', connection);
     await printer.setColumns(42);
     printer.drawer();
     expect(connection.buffer()).toStrictEqual(

--- a/__tests__/profile/Bematech.spec.ts
+++ b/__tests__/profile/Bematech.spec.ts
@@ -1,6 +1,8 @@
 import Model from '../../src/Model';
 import InMemory from '../../src/connection/InMemory';
-import Printer, { Align, Style } from '../../src/Printer';
+import Printer from '../../src/Printer';
+import {Align} from "../../src/Align";
+import {Style} from "../../src/Style";
 import { load } from '../helper';
 
 describe('bematech model profile', () => {

--- a/__tests__/profile/Bematech.spec.ts
+++ b/__tests__/profile/Bematech.spec.ts
@@ -1,77 +1,126 @@
-import Model from '../../src/Model'
-import InMemory from '../../src/connection/InMemory'
-import Printer, { Align, Style } from '../../src/Printer'
-import { load } from '../helper'
+import Model from '../../src/Model';
+import InMemory from '../../src/connection/InMemory';
+import Printer, { Align, Style } from '../../src/Printer';
+import { load } from '../helper';
 
 describe('bematech model profile', () => {
-  it('write bold text from model MP-4200 TH', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('MP-4200 TH'), connection)
-    printer.columns = 42
-    printer.writeln('Bold text', Style.Bold, Align.Center)
-    printer.columns = 50
-    printer.writeln('Bold text', Style.Bold, Align.Center)
-    expect(connection.buffer()).toStrictEqual(load('mp-4200_th_bold_text_font_changed', connection.buffer()))
-  })
+  it('write bold text from model MP-4200 TH', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connectPrinter(
+      await Model.initialise('MP-4200 TH'),
+      connection,
+    );
+    await printer.setColumns(42);
+    await printer.writeln('Bold text', Style.Bold, Align.Center);
+    await printer.setColumns(50);
+    await printer.writeln('Bold text', Style.Bold, Align.Center);
+    expect(connection.buffer()).toStrictEqual(
+      load('mp-4200_th_bold_text_font_changed', connection.buffer()),
+    );
+  });
 
-  it('write bold text on another font from model MP-4200 TH', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('MP-4200 TH'), connection)
-    printer.columns = 42
-    printer.writeln('Bold text', Style.Bold, Align.Center)
-    expect(connection.buffer()).toStrictEqual(load('mp-4200_th_bold_text_other_font', connection.buffer()))
-  })
+  it('write bold text on another font from model MP-4200 TH', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connectPrinter(
+      await Model.initialise('MP-4200 TH'),
+      connection,
+    );
+    await printer.setColumns(42);
+    await printer.writeln('Bold text', Style.Bold, Align.Center);
+    expect(connection.buffer()).toStrictEqual(
+      load('mp-4200_th_bold_text_other_font', connection.buffer()),
+    );
+  });
 
-  it('write text with double width and height from model MP-4200 TH', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('MP-4200 TH'), connection)
-    printer.writeln('Large Text', Style.DoubleWidth + Style.DoubleHeight, Align.Center)
-    expect(connection.buffer()).toStrictEqual(load('mp-4200_th_large_text', connection.buffer()))
-  })
+  it('write text with double width and height from model MP-4200 TH', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connectPrinter(
+      await Model.initialise('MP-4200 TH'),
+      connection,
+    );
+    await printer.writeln(
+      'Large Text',
+      Style.DoubleWidth + Style.DoubleHeight,
+      Align.Center,
+    );
+    expect(connection.buffer()).toStrictEqual(
+      load('mp-4200_th_large_text', connection.buffer()),
+    );
+  });
 
   it('draw qrcode from model MP-4200 TH', async () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('MP-4200 TH'), connection)
-    printer.alignment = Align.Center
-    await printer.qrcode('https://github.com/grandchef/escpos-buffer')
-    printer.alignment = Align.Left
-    expect(connection.buffer()).toStrictEqual(load('mp-4200_th_qrcode', connection.buffer()))
-  })
+    const connection = new InMemory();
+    const printer = await Printer.connectPrinter(
+      await Model.initialise('MP-4200 TH'),
+      connection,
+    );
+    await printer.setAlignment(Align.Center);
+    await printer.qrcode('https://github.com/grandchef/escpos-buffer');
+    await printer.setAlignment(Align.Left);
+    expect(connection.buffer()).toStrictEqual(
+      load('mp-4200_th_qrcode', connection.buffer()),
+    );
+  });
 
-  it('emit buzzer from model MP-4200 TH', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('MP-4200 TH'), connection)
-    printer.buzzer()
-    expect(connection.buffer()).toStrictEqual(load('mp-4200_th_buzzer', connection.buffer()))
-  })
+  it('emit buzzer from model MP-4200 TH', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connectPrinter(
+      await Model.initialise('MP-4200 TH'),
+      connection,
+    );
+    printer.buzzer();
+    expect(connection.buffer()).toStrictEqual(
+      load('mp-4200_th_buzzer', connection.buffer()),
+    );
+  });
 
-  it('emit buzzer from model MP-2800 TH', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('MP-2800 TH'), connection)
-    printer.buzzer()
-    expect(connection.buffer()).toStrictEqual(load('mp-2800_th_buzzer', connection.buffer()))
-  })
+  it('emit buzzer from model MP-2800 TH', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connectPrinter(
+      await Model.initialise('MP-2800 TH'),
+      connection,
+    );
+    printer.buzzer();
+    expect(connection.buffer()).toStrictEqual(
+      load('mp-2800_th_buzzer', connection.buffer()),
+    );
+  });
 
-  it('emit buzzer on another font from model MP-4200 TH', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('MP-4200 TH'), connection)
-    printer.columns = 42
-    printer.buzzer()
-    expect(connection.buffer()).toStrictEqual(load('mp-4200_th_buzzer_other_font', connection.buffer()))
-  })
+  it('emit buzzer on another font from model MP-4200 TH', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connectPrinter(
+      await Model.initialise('MP-4200 TH'),
+      connection,
+    );
+    await printer.setColumns(42);
+    printer.buzzer();
+    expect(connection.buffer()).toStrictEqual(
+      load('mp-4200_th_buzzer_other_font', connection.buffer()),
+    );
+  });
 
-  it('activate drawer from model MP-4200 TH', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('MP-4200 TH'), connection)
-    printer.drawer()
-    expect(connection.buffer()).toStrictEqual(load('mp-4200_th_drawer', connection.buffer()))
-  })
+  it('activate drawer from model MP-4200 TH', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connectPrinter(
+      await Model.initialise('MP-4200 TH'),
+      connection,
+    );
+    printer.drawer();
+    expect(connection.buffer()).toStrictEqual(
+      load('mp-4200_th_drawer', connection.buffer()),
+    );
+  });
 
-  it('activate drawer on another font from model MP-4200 TH', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('MP-4200 TH'), connection)
-    printer.columns = 42
-    printer.drawer()
-    expect(connection.buffer()).toStrictEqual(load('mp-4200_th_drawer_other_font', connection.buffer()))
-  })
-})
+  it('activate drawer on another font from model MP-4200 TH', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connectPrinter(
+      await Model.initialise('MP-4200 TH'),
+      connection,
+    );
+    await printer.setColumns(42);
+    printer.drawer();
+    expect(connection.buffer()).toStrictEqual(
+      load('mp-4200_th_drawer_other_font', connection.buffer()),
+    );
+  });
+});

--- a/__tests__/profile/ControliD.spec.ts
+++ b/__tests__/profile/ControliD.spec.ts
@@ -13,7 +13,7 @@ describe('controlid model profile', () => {
   it('write text using Font B from model PrintiD', () => {
     const connection = new InMemory()
     const printer = new Printer(new Model('PrintiD'), connection)
-    printer.columns = 64
+    printer.setColumns = 64
     printer.writeln('Lorem Ipsum is simply dummy text of the printing and ' +
       'typesetting industry. Lorem Ipsum has been the industry\'s standard' +
       ' dummy text ever since the 1500s', Style.Bold, Align.Center)

--- a/__tests__/profile/ControliD.spec.ts
+++ b/__tests__/profile/ControliD.spec.ts
@@ -1,17 +1,13 @@
-import Model from '../../src/Model';
 import InMemory from '../../src/connection/InMemory';
 import Printer from '../../src/Printer';
-import {Align} from "../../src/Align";
-import {Style} from "../../src/Style";
+import { Align } from '../../src/Align';
+import { Style } from '../../src/Style';
 import { load } from '../helper';
 
 describe('controlid model profile', () => {
   it('write bold text from model PrintiD', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('PrintiD'),
-      connection,
-    );
+    const printer = await Printer.connect('PrintiD', connection);
     await printer.writeln('Bold text', Style.Bold, Align.Center);
     expect(connection.buffer()).toStrictEqual(
       load('printid_bold_text', connection.buffer()),
@@ -20,10 +16,7 @@ describe('controlid model profile', () => {
 
   it('write text using Font B from model PrintiD', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('PrintiD'),
-      connection,
-    );
+    const printer = await Printer.connect('PrintiD', connection);
     await printer.setColumns(64);
     await printer.writeln(
       'Lorem Ipsum is simply dummy text of the printing and ' +
@@ -39,10 +32,7 @@ describe('controlid model profile', () => {
 
   it('write text with double width and height from model PrintiD', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('PrintiD'),
-      connection,
-    );
+    const printer = await Printer.connect('PrintiD', connection);
     await printer.writeln(
       'Large Text',
       Style.DoubleWidth + Style.DoubleHeight,
@@ -55,10 +45,7 @@ describe('controlid model profile', () => {
 
   it('draw qrcode from model PrintiD', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('PrintiD'),
-      connection,
-    );
+    const printer = await Printer.connect('PrintiD', connection);
     await printer.setAlignment(Align.Center);
     await printer.qrcode('https://github.com/grandchef/escpos-buffer');
     await printer.setAlignment(Align.Left);
@@ -69,10 +56,7 @@ describe('controlid model profile', () => {
 
   it('draw qrcode from model PrintiD Touch', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('PrintiD-Touch'),
-      connection,
-    );
+    const printer = await Printer.connect('PrintiD-Touch', connection);
     await printer.setAlignment(Align.Center);
     await printer.qrcode('https://github.com/grandchef/escpos-buffer');
     await printer.setAlignment(Align.Left);

--- a/__tests__/profile/ControliD.spec.ts
+++ b/__tests__/profile/ControliD.spec.ts
@@ -1,47 +1,81 @@
-import Model from '../../src/Model'
-import InMemory from '../../src/connection/InMemory'
-import Printer, { Align, Style } from '../../src/Printer'
-import { load } from '../helper'
+import Model from '../../src/Model';
+import InMemory from '../../src/connection/InMemory';
+import Printer, { Align, Style } from '../../src/Printer';
+import { load } from '../helper';
 
 describe('controlid model profile', () => {
-  it('write bold text from model PrintiD', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('PrintiD'), connection)
-    printer.writeln('Bold text', Style.Bold, Align.Center)
-    expect(connection.buffer()).toStrictEqual(load('printid_bold_text', connection.buffer()))
-  })
-  it('write text using Font B from model PrintiD', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('PrintiD'), connection)
-    printer.setColumns = 64
-    printer.writeln('Lorem Ipsum is simply dummy text of the printing and ' +
-      'typesetting industry. Lorem Ipsum has been the industry\'s standard' +
-      ' dummy text ever since the 1500s', Style.Bold, Align.Center)
-    expect(connection.buffer()).toStrictEqual(load('printid_font_b', connection.buffer()))
-  })
+  it('write bold text from model PrintiD', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('PrintiD'),
+      connection,
+    );
+    await printer.writeln('Bold text', Style.Bold, Align.Center);
+    expect(connection.buffer()).toStrictEqual(
+      load('printid_bold_text', connection.buffer()),
+    );
+  });
 
-  it('write text with double width and height from model PrintiD', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('PrintiD'), connection)
-    printer.writeln('Large Text', Style.DoubleWidth + Style.DoubleHeight, Align.Center)
-    expect(connection.buffer()).toStrictEqual(load('printid_large_text', connection.buffer()))
-  })
+  it('write text using Font B from model PrintiD', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('PrintiD'),
+      connection,
+    );
+    await printer.setColumns(64);
+    await printer.writeln(
+      'Lorem Ipsum is simply dummy text of the printing and ' +
+        "typesetting industry. Lorem Ipsum has been the industry's standard" +
+        ' dummy text ever since the 1500s',
+      Style.Bold,
+      Align.Center,
+    );
+    expect(connection.buffer()).toStrictEqual(
+      load('printid_font_b', connection.buffer()),
+    );
+  });
+
+  it('write text with double width and height from model PrintiD', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('PrintiD'),
+      connection,
+    );
+    await printer.writeln(
+      'Large Text',
+      Style.DoubleWidth + Style.DoubleHeight,
+      Align.Center,
+    );
+    expect(connection.buffer()).toStrictEqual(
+      load('printid_large_text', connection.buffer()),
+    );
+  });
 
   it('draw qrcode from model PrintiD', async () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('PrintiD'), connection)
-    printer.alignment = Align.Center
-    await printer.qrcode('https://github.com/grandchef/escpos-buffer')
-    printer.alignment = Align.Left
-    expect(connection.buffer()).toStrictEqual(load('printid_qrcode', connection.buffer()))
-  })
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('PrintiD'),
+      connection,
+    );
+    await printer.setAlignment(Align.Center);
+    await printer.qrcode('https://github.com/grandchef/escpos-buffer');
+    await printer.setAlignment(Align.Left);
+    expect(connection.buffer()).toStrictEqual(
+      load('printid_qrcode', connection.buffer()),
+    );
+  });
 
   it('draw qrcode from model PrintiD Touch', async () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('PrintiD-Touch'), connection)
-    printer.alignment = Align.Center
-    await printer.qrcode('https://github.com/grandchef/escpos-buffer')
-    printer.alignment = Align.Left
-    expect(connection.buffer()).toStrictEqual(load('printid_touch_qrcode', connection.buffer()))
-  })
-})
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('PrintiD-Touch'),
+      connection,
+    );
+    await printer.setAlignment(Align.Center);
+    await printer.qrcode('https://github.com/grandchef/escpos-buffer');
+    await printer.setAlignment(Align.Left);
+    expect(connection.buffer()).toStrictEqual(
+      load('printid_touch_qrcode', connection.buffer()),
+    );
+  });
+});

--- a/__tests__/profile/ControliD.spec.ts
+++ b/__tests__/profile/ControliD.spec.ts
@@ -1,6 +1,8 @@
 import Model from '../../src/Model';
 import InMemory from '../../src/connection/InMemory';
-import Printer, { Align, Style } from '../../src/Printer';
+import Printer from '../../src/Printer';
+import {Align} from "../../src/Align";
+import {Style} from "../../src/Style";
 import { load } from '../helper';
 
 describe('controlid model profile', () => {

--- a/__tests__/profile/ControliD.spec.ts
+++ b/__tests__/profile/ControliD.spec.ts
@@ -7,7 +7,7 @@ import { load } from '../helper';
 describe('controlid model profile', () => {
   it('write bold text from model PrintiD', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('PrintiD', connection);
+    const printer = await Printer.CONNECT('PrintiD', connection);
     await printer.writeln('Bold text', Style.Bold, Align.Center);
     expect(connection.buffer()).toStrictEqual(
       load('printid_bold_text', connection.buffer()),
@@ -16,7 +16,7 @@ describe('controlid model profile', () => {
 
   it('write text using Font B from model PrintiD', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('PrintiD', connection);
+    const printer = await Printer.CONNECT('PrintiD', connection);
     await printer.setColumns(64);
     await printer.writeln(
       'Lorem Ipsum is simply dummy text of the printing and ' +
@@ -32,7 +32,7 @@ describe('controlid model profile', () => {
 
   it('write text with double width and height from model PrintiD', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('PrintiD', connection);
+    const printer = await Printer.CONNECT('PrintiD', connection);
     await printer.writeln(
       'Large Text',
       Style.DoubleWidth + Style.DoubleHeight,
@@ -45,7 +45,7 @@ describe('controlid model profile', () => {
 
   it('draw qrcode from model PrintiD', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('PrintiD', connection);
+    const printer = await Printer.CONNECT('PrintiD', connection);
     await printer.setAlignment(Align.Center);
     await printer.qrcode('https://github.com/grandchef/escpos-buffer');
     await printer.setAlignment(Align.Left);
@@ -56,7 +56,7 @@ describe('controlid model profile', () => {
 
   it('draw qrcode from model PrintiD Touch', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('PrintiD-Touch', connection);
+    const printer = await Printer.CONNECT('PrintiD-Touch', connection);
     await printer.setAlignment(Align.Center);
     await printer.qrcode('https://github.com/grandchef/escpos-buffer');
     await printer.setAlignment(Align.Left);

--- a/__tests__/profile/Daruma.spec.ts
+++ b/__tests__/profile/Daruma.spec.ts
@@ -8,7 +8,7 @@ import { Image } from '../../src';
 describe('daruma model profile', () => {
   it('write bold text from model DR800', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('DR800', connection);
+    const printer = await Printer.CONNECT('DR800', connection);
     await printer.writeln('Bold text', Style.Bold, Align.Center);
     expect(connection.buffer()).toStrictEqual(
       load('dr800_bold_text', connection.buffer()),
@@ -17,7 +17,7 @@ describe('daruma model profile', () => {
 
   it('write text with double width and height from model DR800', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('DR800', connection);
+    const printer = await Printer.CONNECT('DR800', connection);
     await printer.writeln(
       'Large Text',
       Style.DoubleWidth + Style.DoubleHeight,
@@ -30,7 +30,7 @@ describe('daruma model profile', () => {
 
   it('activate drawer from model DR800', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('DR800', connection);
+    const printer = await Printer.CONNECT('DR800', connection);
     await printer.drawer();
     expect(connection.buffer()).toStrictEqual(
       load('dr800_drawer', connection.buffer()),
@@ -39,7 +39,7 @@ describe('daruma model profile', () => {
 
   it('draw qrcode from model DR800', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('DR800', connection);
+    const printer = await Printer.CONNECT('DR800', connection);
     await printer.setAlignment(Align.Center);
     await printer.qrcode('https://github.com/grandchef/escpos-buffer');
     await printer.setAlignment(Align.Left);
@@ -50,7 +50,7 @@ describe('daruma model profile', () => {
 
   it('draw picture from buffer from model DR800', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('DR800', connection);
+    const printer = await Printer.CONNECT('DR800', connection);
     const image = new Image(load('sample.png'));
     await printer.setAlignment(Align.Center);
     await printer.draw(image);

--- a/__tests__/profile/Daruma.spec.ts
+++ b/__tests__/profile/Daruma.spec.ts
@@ -1,6 +1,8 @@
 import Model from '../../src/Model';
 import InMemory from '../../src/connection/InMemory';
-import Printer, { Align, Style } from '../../src/Printer';
+import Printer from '../../src/Printer';
+import {Align} from "../../src/Align";
+import {Style} from "../../src/Style";
 import { load } from '../helper';
 import { Image } from '../../src';
 

--- a/__tests__/profile/Daruma.spec.ts
+++ b/__tests__/profile/Daruma.spec.ts
@@ -1,48 +1,77 @@
-import Model from '../../src/Model'
-import InMemory from '../../src/connection/InMemory'
-import Printer, { Align, Style } from '../../src/Printer'
-import { load } from '../helper'
-import { Image } from '../../src'
+import Model from '../../src/Model';
+import InMemory from '../../src/connection/InMemory';
+import Printer, { Align, Style } from '../../src/Printer';
+import { load } from '../helper';
+import { Image } from '../../src';
 
 describe('daruma model profile', () => {
-  it('write bold text from model DR800', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('DR800'), connection)
-    printer.writeln('Bold text', Style.Bold, Align.Center)
-    expect(connection.buffer()).toStrictEqual(load('dr800_bold_text', connection.buffer()))
-  })
+  it('write bold text from model DR800', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('DR800'),
+      connection,
+    );
+    await printer.writeln('Bold text', Style.Bold, Align.Center);
+    expect(connection.buffer()).toStrictEqual(
+      load('dr800_bold_text', connection.buffer()),
+    );
+  });
 
-  it('write text with double width and height from model DR800', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('DR800'), connection)
-    printer.writeln('Large Text', Style.DoubleWidth + Style.DoubleHeight, Align.Center)
-    expect(connection.buffer()).toStrictEqual(load('dr800_large_text', connection.buffer()))
-  })
+  it('write text with double width and height from model DR800', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('DR800'),
+      connection,
+    );
+    await printer.writeln(
+      'Large Text',
+      Style.DoubleWidth + Style.DoubleHeight,
+      Align.Center,
+    );
+    expect(connection.buffer()).toStrictEqual(
+      load('dr800_large_text', connection.buffer()),
+    );
+  });
 
-  it('activate drawer from model DR800', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('DR800'), connection)
-    printer.drawer()
-    expect(connection.buffer()).toStrictEqual(load('dr800_drawer', connection.buffer()))
-  })
+  it('activate drawer from model DR800', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('DR800'),
+      connection,
+    );
+    await printer.drawer();
+    expect(connection.buffer()).toStrictEqual(
+      load('dr800_drawer', connection.buffer()),
+    );
+  });
 
   it('draw qrcode from model DR800', async () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('DR800'), connection)
-    printer.alignment = Align.Center
-    await printer.qrcode('https://github.com/grandchef/escpos-buffer')
-    printer.alignment = Align.Left
-    expect(connection.buffer()).toStrictEqual(load('dr800_qrcode', connection.buffer()))
-  })
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('DR800'),
+      connection,
+    );
+    await printer.setAlignment(Align.Center);
+    await printer.qrcode('https://github.com/grandchef/escpos-buffer');
+    await printer.setAlignment(Align.Left);
+    expect(connection.buffer()).toStrictEqual(
+      load('dr800_qrcode', connection.buffer()),
+    );
+  });
 
-  it('draw picture from buffer from model DR800', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('DR800'), connection)
-    const image = new Image(load('sample.png'))
-    printer.alignment = Align.Center
-    printer.draw(image)
-    printer.alignment = Align.Left
-    printer.close()
-    expect(connection.buffer()).toStrictEqual(load('dr800_draw_buffer', connection.buffer()))
-  })
-})
+  it('draw picture from buffer from model DR800', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('DR800'),
+      connection,
+    );
+    const image = new Image(load('sample.png'));
+    await printer.setAlignment(Align.Center);
+    await printer.draw(image);
+    await printer.setAlignment(Align.Left);
+    await printer.close();
+    expect(connection.buffer()).toStrictEqual(
+      load('dr800_draw_buffer', connection.buffer()),
+    );
+  });
+});

--- a/__tests__/profile/Daruma.spec.ts
+++ b/__tests__/profile/Daruma.spec.ts
@@ -1,18 +1,14 @@
-import Model from '../../src/Model';
 import InMemory from '../../src/connection/InMemory';
 import Printer from '../../src/Printer';
-import {Align} from "../../src/Align";
-import {Style} from "../../src/Style";
+import { Align } from '../../src/Align';
+import { Style } from '../../src/Style';
 import { load } from '../helper';
 import { Image } from '../../src';
 
 describe('daruma model profile', () => {
   it('write bold text from model DR800', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('DR800'),
-      connection,
-    );
+    const printer = await Printer.connect('DR800', connection);
     await printer.writeln('Bold text', Style.Bold, Align.Center);
     expect(connection.buffer()).toStrictEqual(
       load('dr800_bold_text', connection.buffer()),
@@ -21,10 +17,7 @@ describe('daruma model profile', () => {
 
   it('write text with double width and height from model DR800', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('DR800'),
-      connection,
-    );
+    const printer = await Printer.connect('DR800', connection);
     await printer.writeln(
       'Large Text',
       Style.DoubleWidth + Style.DoubleHeight,
@@ -37,10 +30,7 @@ describe('daruma model profile', () => {
 
   it('activate drawer from model DR800', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('DR800'),
-      connection,
-    );
+    const printer = await Printer.connect('DR800', connection);
     await printer.drawer();
     expect(connection.buffer()).toStrictEqual(
       load('dr800_drawer', connection.buffer()),
@@ -49,10 +39,7 @@ describe('daruma model profile', () => {
 
   it('draw qrcode from model DR800', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('DR800'),
-      connection,
-    );
+    const printer = await Printer.connect('DR800', connection);
     await printer.setAlignment(Align.Center);
     await printer.qrcode('https://github.com/grandchef/escpos-buffer');
     await printer.setAlignment(Align.Left);
@@ -63,10 +50,7 @@ describe('daruma model profile', () => {
 
   it('draw picture from buffer from model DR800', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('DR800'),
-      connection,
-    );
+    const printer = await Printer.connect('DR800', connection);
     const image = new Image(load('sample.png'));
     await printer.setAlignment(Align.Center);
     await printer.draw(image);

--- a/__tests__/profile/Dataregis.spec.ts
+++ b/__tests__/profile/Dataregis.spec.ts
@@ -5,7 +5,7 @@ import { load } from '../helper';
 describe('dataregis model profile', () => {
   it('emit buzzer from model DT200', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('DT200', connection);
+    const printer = await Printer.CONNECT('DT200', connection);
     await printer.buzzer();
     expect(connection.buffer()).toStrictEqual(
       load('dt200_buzzer', connection.buffer()),

--- a/__tests__/profile/Dataregis.spec.ts
+++ b/__tests__/profile/Dataregis.spec.ts
@@ -1,4 +1,3 @@
-import Model from '../../src/Model';
 import InMemory from '../../src/connection/InMemory';
 import Printer from '../../src/Printer';
 import { load } from '../helper';
@@ -6,10 +5,7 @@ import { load } from '../helper';
 describe('dataregis model profile', () => {
   it('emit buzzer from model DT200', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('DT200'),
-      connection,
-    );
+    const printer = await Printer.connect('DT200', connection);
     await printer.buzzer();
     expect(connection.buffer()).toStrictEqual(
       load('dt200_buzzer', connection.buffer()),

--- a/__tests__/profile/Dataregis.spec.ts
+++ b/__tests__/profile/Dataregis.spec.ts
@@ -1,13 +1,18 @@
-import Model from '../../src/Model'
-import InMemory from '../../src/connection/InMemory'
-import Printer from '../../src/Printer'
-import { load } from '../helper'
+import Model from '../../src/Model';
+import InMemory from '../../src/connection/InMemory';
+import Printer from '../../src/Printer';
+import { load } from '../helper';
 
 describe('dataregis model profile', () => {
-  it('emit buzzer from model DT200', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('DT200'), connection)
-    printer.buzzer()
-    expect(connection.buffer()).toStrictEqual(load('dt200_buzzer', connection.buffer()))
-  })
-})
+  it('emit buzzer from model DT200', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('DT200'),
+      connection,
+    );
+    await printer.buzzer();
+    expect(connection.buffer()).toStrictEqual(
+      load('dt200_buzzer', connection.buffer()),
+    );
+  });
+});

--- a/__tests__/profile/Diebold.spec.ts
+++ b/__tests__/profile/Diebold.spec.ts
@@ -5,7 +5,7 @@ import { load } from '../helper';
 describe('diebold model profile', () => {
   it('emit buzzer from model TSP-143', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('TSP-143', connection);
+    const printer = await Printer.CONNECT('TSP-143', connection);
     await printer.buzzer();
     expect(connection.buffer()).toStrictEqual(
       load('tsp-143_buzzer', connection.buffer()),
@@ -14,7 +14,7 @@ describe('diebold model profile', () => {
 
   it('activate drawer from model TSP-143', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('TSP-143', connection);
+    const printer = await Printer.CONNECT('TSP-143', connection);
     await printer.drawer();
     expect(connection.buffer()).toStrictEqual(
       load('tsp-143_drawer', connection.buffer()),

--- a/__tests__/profile/Diebold.spec.ts
+++ b/__tests__/profile/Diebold.spec.ts
@@ -1,4 +1,3 @@
-import Model from '../../src/Model';
 import InMemory from '../../src/connection/InMemory';
 import Printer from '../../src/Printer';
 import { load } from '../helper';
@@ -6,10 +5,7 @@ import { load } from '../helper';
 describe('diebold model profile', () => {
   it('emit buzzer from model TSP-143', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('TSP-143'),
-      connection,
-    );
+    const printer = await Printer.connect('TSP-143', connection);
     await printer.buzzer();
     expect(connection.buffer()).toStrictEqual(
       load('tsp-143_buzzer', connection.buffer()),
@@ -18,10 +14,7 @@ describe('diebold model profile', () => {
 
   it('activate drawer from model TSP-143', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('TSP-143'),
-      connection,
-    );
+    const printer = await Printer.connect('TSP-143', connection);
     await printer.drawer();
     expect(connection.buffer()).toStrictEqual(
       load('tsp-143_drawer', connection.buffer()),

--- a/__tests__/profile/Diebold.spec.ts
+++ b/__tests__/profile/Diebold.spec.ts
@@ -1,20 +1,30 @@
-import Model from '../../src/Model'
-import InMemory from '../../src/connection/InMemory'
-import Printer from '../../src/Printer'
-import { load } from '../helper'
+import Model from '../../src/Model';
+import InMemory from '../../src/connection/InMemory';
+import Printer from '../../src/Printer';
+import { load } from '../helper';
 
 describe('diebold model profile', () => {
-  it('emit buzzer from model TSP-143', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('TSP-143'), connection)
-    printer.buzzer()
-    expect(connection.buffer()).toStrictEqual(load('tsp-143_buzzer', connection.buffer()))
-  })
+  it('emit buzzer from model TSP-143', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('TSP-143'),
+      connection,
+    );
+    await printer.buzzer();
+    expect(connection.buffer()).toStrictEqual(
+      load('tsp-143_buzzer', connection.buffer()),
+    );
+  });
 
-  it('activate drawer from model TSP-143', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('TSP-143'), connection)
-    printer.drawer()
-    expect(connection.buffer()).toStrictEqual(load('tsp-143_drawer', connection.buffer()))
-  })
-})
+  it('activate drawer from model TSP-143', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('TSP-143'),
+      connection,
+    );
+    await printer.drawer();
+    expect(connection.buffer()).toStrictEqual(
+      load('tsp-143_drawer', connection.buffer()),
+    );
+  });
+});

--- a/__tests__/profile/Elgin.spec.ts
+++ b/__tests__/profile/Elgin.spec.ts
@@ -139,7 +139,7 @@ describe('elgin model profile', () => {
       await Model.initialise('VOX'),
       connection,
     );
-    printer.writeln('Bold text', Style.Bold, Align.Center);
+    await printer.writeln('Bold text', Style.Bold, Align.Center);
     expect(connection.buffer()).toStrictEqual(
       load('vox_bold_text', connection.buffer()),
     );
@@ -151,7 +151,7 @@ describe('elgin model profile', () => {
       await Model.initialise('VOX'),
       connection,
     );
-    printer.writeln(
+    await printer.writeln(
       'Large Text',
       Style.DoubleWidth + Style.DoubleHeight,
       Align.Center,

--- a/__tests__/profile/Elgin.spec.ts
+++ b/__tests__/profile/Elgin.spec.ts
@@ -1,104 +1,177 @@
-import Model from '../../src/Model'
-import InMemory from '../../src/connection/InMemory'
-import Printer, { Align, Style, Cut } from '../../src/Printer'
-import { load } from '../helper'
+import Model from '../../src/Model';
+import InMemory from '../../src/connection/InMemory';
+import Printer, { Align, Style, Cut } from '../../src/Printer';
+import { load } from '../helper';
 
 describe('elgin model profile', () => {
-  it('write bold text from model I9', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('I9'), connection)
-    printer.writeln('Bold text', Style.Bold, Align.Center)
-    expect(connection.buffer()).toStrictEqual(load('i9_bold_text', connection.buffer()))
-  })
+  it('write bold text from model I9', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('I9'),
+      connection,
+    );
+    await printer.writeln('Bold text', Style.Bold, Align.Center);
+    expect(connection.buffer()).toStrictEqual(
+      load('i9_bold_text', connection.buffer()),
+    );
+  });
 
-  it('write text with double width and height from model I9', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('I9'), connection)
-    printer.writeln('Large Text', Style.DoubleWidth + Style.DoubleHeight, Align.Center)
-    expect(connection.buffer()).toStrictEqual(load('i9_large_text', connection.buffer()))
-  })
+  it('write text with double width and height from model I9', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('I9'),
+      connection,
+    );
+    await printer.writeln(
+      'Large Text',
+      Style.DoubleWidth + Style.DoubleHeight,
+      Align.Center,
+    );
+    expect(connection.buffer()).toStrictEqual(
+      load('i9_large_text', connection.buffer()),
+    );
+  });
 
   it('draw qrcode from model I9', async () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('I9'), connection)
-    printer.alignment = Align.Center
-    await printer.qrcode('https://github.com/grandchef/escpos-buffer')
-    printer.alignment = Align.Left
-    expect(connection.buffer()).toStrictEqual(load('i9_qrcode', connection.buffer()))
-  })
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('I9'),
+      connection,
+    );
+    await printer.setAlignment(Align.Center);
+    await printer.qrcode('https://github.com/grandchef/escpos-buffer');
+    await printer.setAlignment(Align.Left);
+    expect(connection.buffer()).toStrictEqual(
+      load('i9_qrcode', connection.buffer()),
+    );
+  });
 
-  it('emit buzzer from model I9', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('I9'), connection)
-    printer.buzzer()
-    expect(connection.buffer()).toStrictEqual(load('i9_buzzer', connection.buffer()))
-  })
+  it('emit buzzer from model I9', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('I9'),
+      connection,
+    );
+    await printer.buzzer();
+    expect(connection.buffer()).toStrictEqual(
+      load('i9_buzzer', connection.buffer()),
+    );
+  });
 
-  it('activate drawer from model I9', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('I9'), connection)
-    printer.drawer()
-    expect(connection.buffer()).toStrictEqual(load('i9_drawer', connection.buffer()))
-  })
+  it('activate drawer from model I9', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('I9'),
+      connection,
+    );
+    await printer.drawer();
+    expect(connection.buffer()).toStrictEqual(
+      load('i9_drawer', connection.buffer()),
+    );
+  });
 
-  it('activate drawer from model VOX', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('VOX'), connection)
-    printer.drawer()
-    expect(connection.buffer()).toStrictEqual(load('vox_drawer', connection.buffer()))
-  })
+  it('activate drawer from model VOX', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('VOX'),
+      connection,
+    );
+    await printer.drawer();
+    expect(connection.buffer()).toStrictEqual(
+      load('vox_drawer', connection.buffer()),
+    );
+  });
 
-  it('activate drawer from model I7', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('I7'), connection)
-    printer.drawer()
-    expect(connection.buffer()).toStrictEqual(load('i7_drawer', connection.buffer()))
-  })
+  it('activate drawer from model I7', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('I7'),
+      connection,
+    );
+    printer.drawer();
+    expect(connection.buffer()).toStrictEqual(
+      load('i7_drawer', connection.buffer()),
+    );
+  });
 
-  it('cut paper partially from model I9', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('I9'), connection)
-    printer.writeln('Cut below', 0, Align.Center)
-    printer.cutter()
-    expect(connection.buffer()).toStrictEqual(load('i9_cutter', connection.buffer()))
-  })
+  it('cut paper partially from model I9', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('I9'),
+      connection,
+    );
+    await printer.writeln('Cut below', 0, Align.Center);
+    await printer.cutter();
+    expect(connection.buffer()).toStrictEqual(
+      load('i9_cutter', connection.buffer()),
+    );
+  });
 
-  it('cut entire paper from model I9', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('I9'), connection)
-    printer.writeln('Cut below', 0, Align.Center)
-    printer.cutter(Cut.Full)
-    expect(connection.buffer()).toStrictEqual(load('i9_cutter_full', connection.buffer()))
-  })
+  it('cut entire paper from model I9', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('I9'),
+      connection,
+    );
+    await printer.writeln('Cut below', 0, Align.Center);
+    await printer.cutter(Cut.Full);
+    expect(connection.buffer()).toStrictEqual(
+      load('i9_cutter_full', connection.buffer()),
+    );
+  });
 
-  it('cut paper partially from model VOX', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('VOX'), connection)
-    printer.writeln('Cut below', 0, Align.Center)
-    printer.cutter()
-    expect(connection.buffer()).toStrictEqual(load('vox_cutter', connection.buffer()))
-  })
+  it('cut paper partially from model VOX', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('VOX'),
+      connection,
+    );
+    await printer.writeln('Cut below', 0, Align.Center);
+    await printer.cutter();
+    expect(connection.buffer()).toStrictEqual(
+      load('vox_cutter', connection.buffer()),
+    );
+  });
 
-  it('write bold text from model VOX', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('VOX'), connection)
-    printer.writeln('Bold text', Style.Bold, Align.Center)
-    expect(connection.buffer()).toStrictEqual(load('vox_bold_text', connection.buffer()))
-  })
+  it('write bold text from model VOX', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('VOX'),
+      connection,
+    );
+    printer.writeln('Bold text', Style.Bold, Align.Center);
+    expect(connection.buffer()).toStrictEqual(
+      load('vox_bold_text', connection.buffer()),
+    );
+  });
 
-  it('write text with double width and height from model VOX', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('VOX'), connection)
-    printer.writeln('Large Text', Style.DoubleWidth + Style.DoubleHeight, Align.Center)
-    expect(connection.buffer()).toStrictEqual(load('vox_large_text', connection.buffer()))
-  })
+  it('write text with double width and height from model VOX', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('VOX'),
+      connection,
+    );
+    printer.writeln(
+      'Large Text',
+      Style.DoubleWidth + Style.DoubleHeight,
+      Align.Center,
+    );
+    expect(connection.buffer()).toStrictEqual(
+      load('vox_large_text', connection.buffer()),
+    );
+  });
 
   it('draw qrcode from model VOX', async () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('VOX'), connection)
-    printer.alignment = Align.Center
-    await printer.qrcode('https://github.com/grandchef/escpos-buffer')
-    printer.alignment = Align.Left
-    expect(connection.buffer()).toStrictEqual(load('vox_qrcode', connection.buffer()))
-  })
-})
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('VOX'),
+      connection,
+    );
+    await printer.setAlignment(Align.Center);
+    await printer.qrcode('https://github.com/grandchef/escpos-buffer');
+    await printer.setAlignment(Align.Left);
+    expect(connection.buffer()).toStrictEqual(
+      load('vox_qrcode', connection.buffer()),
+    );
+  });
+});

--- a/__tests__/profile/Elgin.spec.ts
+++ b/__tests__/profile/Elgin.spec.ts
@@ -1,6 +1,9 @@
 import Model from '../../src/Model';
 import InMemory from '../../src/connection/InMemory';
-import Printer, { Align, Style, Cut } from '../../src/Printer';
+import Printer from '../../src/Printer';
+import {Align} from "../../src/Align";
+import {Style} from "../../src/Style";
+import {Cut} from "../../src/Cut";
 import { load } from '../helper';
 
 describe('elgin model profile', () => {

--- a/__tests__/profile/Elgin.spec.ts
+++ b/__tests__/profile/Elgin.spec.ts
@@ -8,7 +8,7 @@ import { load } from '../helper';
 describe('elgin model profile', () => {
   it('write bold text from model I9', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('I9', connection);
+    const printer = await Printer.CONNECT('I9', connection);
     await printer.writeln('Bold text', Style.Bold, Align.Center);
     expect(connection.buffer()).toStrictEqual(
       load('i9_bold_text', connection.buffer()),
@@ -17,7 +17,7 @@ describe('elgin model profile', () => {
 
   it('write text with double width and height from model I9', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('I9', connection);
+    const printer = await Printer.CONNECT('I9', connection);
     await printer.writeln(
       'Large Text',
       Style.DoubleWidth + Style.DoubleHeight,
@@ -30,7 +30,7 @@ describe('elgin model profile', () => {
 
   it('draw qrcode from model I9', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('I9', connection);
+    const printer = await Printer.CONNECT('I9', connection);
     await printer.setAlignment(Align.Center);
     await printer.qrcode('https://github.com/grandchef/escpos-buffer');
     await printer.setAlignment(Align.Left);
@@ -41,7 +41,7 @@ describe('elgin model profile', () => {
 
   it('emit buzzer from model I9', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('I9', connection);
+    const printer = await Printer.CONNECT('I9', connection);
     await printer.buzzer();
     expect(connection.buffer()).toStrictEqual(
       load('i9_buzzer', connection.buffer()),
@@ -50,7 +50,7 @@ describe('elgin model profile', () => {
 
   it('activate drawer from model I9', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('I9', connection);
+    const printer = await Printer.CONNECT('I9', connection);
     await printer.drawer();
     expect(connection.buffer()).toStrictEqual(
       load('i9_drawer', connection.buffer()),
@@ -59,7 +59,7 @@ describe('elgin model profile', () => {
 
   it('activate drawer from model VOX', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('VOX', connection);
+    const printer = await Printer.CONNECT('VOX', connection);
     await printer.drawer();
     expect(connection.buffer()).toStrictEqual(
       load('vox_drawer', connection.buffer()),
@@ -68,7 +68,7 @@ describe('elgin model profile', () => {
 
   it('activate drawer from model I7', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('I7', connection);
+    const printer = await Printer.CONNECT('I7', connection);
     printer.drawer();
     expect(connection.buffer()).toStrictEqual(
       load('i7_drawer', connection.buffer()),
@@ -77,7 +77,7 @@ describe('elgin model profile', () => {
 
   it('cut paper partially from model I9', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('I9', connection);
+    const printer = await Printer.CONNECT('I9', connection);
     await printer.writeln('Cut below', 0, Align.Center);
     await printer.cutter();
     expect(connection.buffer()).toStrictEqual(
@@ -87,7 +87,7 @@ describe('elgin model profile', () => {
 
   it('cut entire paper from model I9', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('I9', connection);
+    const printer = await Printer.CONNECT('I9', connection);
     await printer.writeln('Cut below', 0, Align.Center);
     await printer.cutter(Cut.Full);
     expect(connection.buffer()).toStrictEqual(
@@ -97,7 +97,7 @@ describe('elgin model profile', () => {
 
   it('cut paper partially from model VOX', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('VOX', connection);
+    const printer = await Printer.CONNECT('VOX', connection);
     await printer.writeln('Cut below', 0, Align.Center);
     await printer.cutter();
     expect(connection.buffer()).toStrictEqual(
@@ -107,7 +107,7 @@ describe('elgin model profile', () => {
 
   it('write bold text from model VOX', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('VOX', connection);
+    const printer = await Printer.CONNECT('VOX', connection);
     await printer.writeln('Bold text', Style.Bold, Align.Center);
     expect(connection.buffer()).toStrictEqual(
       load('vox_bold_text', connection.buffer()),
@@ -116,7 +116,7 @@ describe('elgin model profile', () => {
 
   it('write text with double width and height from model VOX', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('VOX', connection);
+    const printer = await Printer.CONNECT('VOX', connection);
     await printer.writeln(
       'Large Text',
       Style.DoubleWidth + Style.DoubleHeight,
@@ -129,7 +129,7 @@ describe('elgin model profile', () => {
 
   it('draw qrcode from model VOX', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('VOX', connection);
+    const printer = await Printer.CONNECT('VOX', connection);
     await printer.setAlignment(Align.Center);
     await printer.qrcode('https://github.com/grandchef/escpos-buffer');
     await printer.setAlignment(Align.Left);

--- a/__tests__/profile/Elgin.spec.ts
+++ b/__tests__/profile/Elgin.spec.ts
@@ -1,18 +1,14 @@
-import Model from '../../src/Model';
 import InMemory from '../../src/connection/InMemory';
 import Printer from '../../src/Printer';
-import {Align} from "../../src/Align";
-import {Style} from "../../src/Style";
-import {Cut} from "../../src/Cut";
+import { Align } from '../../src/Align';
+import { Style } from '../../src/Style';
+import { Cut } from '../../src/Cut';
 import { load } from '../helper';
 
 describe('elgin model profile', () => {
   it('write bold text from model I9', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('I9'),
-      connection,
-    );
+    const printer = await Printer.connect('I9', connection);
     await printer.writeln('Bold text', Style.Bold, Align.Center);
     expect(connection.buffer()).toStrictEqual(
       load('i9_bold_text', connection.buffer()),
@@ -21,10 +17,7 @@ describe('elgin model profile', () => {
 
   it('write text with double width and height from model I9', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('I9'),
-      connection,
-    );
+    const printer = await Printer.connect('I9', connection);
     await printer.writeln(
       'Large Text',
       Style.DoubleWidth + Style.DoubleHeight,
@@ -37,10 +30,7 @@ describe('elgin model profile', () => {
 
   it('draw qrcode from model I9', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('I9'),
-      connection,
-    );
+    const printer = await Printer.connect('I9', connection);
     await printer.setAlignment(Align.Center);
     await printer.qrcode('https://github.com/grandchef/escpos-buffer');
     await printer.setAlignment(Align.Left);
@@ -51,10 +41,7 @@ describe('elgin model profile', () => {
 
   it('emit buzzer from model I9', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('I9'),
-      connection,
-    );
+    const printer = await Printer.connect('I9', connection);
     await printer.buzzer();
     expect(connection.buffer()).toStrictEqual(
       load('i9_buzzer', connection.buffer()),
@@ -63,10 +50,7 @@ describe('elgin model profile', () => {
 
   it('activate drawer from model I9', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('I9'),
-      connection,
-    );
+    const printer = await Printer.connect('I9', connection);
     await printer.drawer();
     expect(connection.buffer()).toStrictEqual(
       load('i9_drawer', connection.buffer()),
@@ -75,10 +59,7 @@ describe('elgin model profile', () => {
 
   it('activate drawer from model VOX', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('VOX'),
-      connection,
-    );
+    const printer = await Printer.connect('VOX', connection);
     await printer.drawer();
     expect(connection.buffer()).toStrictEqual(
       load('vox_drawer', connection.buffer()),
@@ -87,10 +68,7 @@ describe('elgin model profile', () => {
 
   it('activate drawer from model I7', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('I7'),
-      connection,
-    );
+    const printer = await Printer.connect('I7', connection);
     printer.drawer();
     expect(connection.buffer()).toStrictEqual(
       load('i7_drawer', connection.buffer()),
@@ -99,10 +77,7 @@ describe('elgin model profile', () => {
 
   it('cut paper partially from model I9', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('I9'),
-      connection,
-    );
+    const printer = await Printer.connect('I9', connection);
     await printer.writeln('Cut below', 0, Align.Center);
     await printer.cutter();
     expect(connection.buffer()).toStrictEqual(
@@ -112,10 +87,7 @@ describe('elgin model profile', () => {
 
   it('cut entire paper from model I9', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('I9'),
-      connection,
-    );
+    const printer = await Printer.connect('I9', connection);
     await printer.writeln('Cut below', 0, Align.Center);
     await printer.cutter(Cut.Full);
     expect(connection.buffer()).toStrictEqual(
@@ -125,10 +97,7 @@ describe('elgin model profile', () => {
 
   it('cut paper partially from model VOX', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('VOX'),
-      connection,
-    );
+    const printer = await Printer.connect('VOX', connection);
     await printer.writeln('Cut below', 0, Align.Center);
     await printer.cutter();
     expect(connection.buffer()).toStrictEqual(
@@ -138,10 +107,7 @@ describe('elgin model profile', () => {
 
   it('write bold text from model VOX', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('VOX'),
-      connection,
-    );
+    const printer = await Printer.connect('VOX', connection);
     await printer.writeln('Bold text', Style.Bold, Align.Center);
     expect(connection.buffer()).toStrictEqual(
       load('vox_bold_text', connection.buffer()),
@@ -150,10 +116,7 @@ describe('elgin model profile', () => {
 
   it('write text with double width and height from model VOX', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('VOX'),
-      connection,
-    );
+    const printer = await Printer.connect('VOX', connection);
     await printer.writeln(
       'Large Text',
       Style.DoubleWidth + Style.DoubleHeight,
@@ -166,10 +129,7 @@ describe('elgin model profile', () => {
 
   it('draw qrcode from model VOX', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('VOX'),
-      connection,
-    );
+    const printer = await Printer.connect('VOX', connection);
     await printer.setAlignment(Align.Center);
     await printer.qrcode('https://github.com/grandchef/escpos-buffer');
     await printer.setAlignment(Align.Left);

--- a/__tests__/profile/Epson.spec.ts
+++ b/__tests__/profile/Epson.spec.ts
@@ -9,7 +9,7 @@ describe('epson model profile', () => {
   it('write text from model TM-T20', async () => {
     const connection = new InMemory();
     const model = 'TM-T20';
-    const printer = await Printer.connect(model, connection);
+    const printer = await Printer.CONNECT(model, connection);
     await printer.writeln('Large Text');
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_text', connection.buffer()),
@@ -19,7 +19,7 @@ describe('epson model profile', () => {
   it('write text with double width and height from model TM-T20', async () => {
     const connection = new InMemory();
     const model = new Model('TM-T20');
-    const printer = await Printer.connect(model, connection);
+    const printer = await Printer.CONNECT(model, connection);
     await printer.setColumns(64);
     await printer.writeln(
       'Large Text',
@@ -36,7 +36,7 @@ describe('epson model profile', () => {
 
   it('draw qrcode from model TM-T20', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('TM-T20', connection);
+    const printer = await Printer.CONNECT('TM-T20', connection);
     await printer.setAlignment(Align.Center);
     await printer.qrcode('https://github.com/grandchef/escpos-buffer');
     await printer.setAlignment(Align.Left);
@@ -47,7 +47,7 @@ describe('epson model profile', () => {
 
   it('sets char size from the style and clears it after', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('TM-T20', connection);
+    const printer = await Printer.CONNECT('TM-T20', connection);
     const cb = jest.fn();
     const width = 4;
     const height = 6;
@@ -63,7 +63,7 @@ describe('epson model profile', () => {
 
   it('defaults width to 1', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('TM-T20', connection);
+    const printer = await Printer.CONNECT('TM-T20', connection);
     const cb = jest.fn();
     const height = 6;
     await printer.withStyle({ height }, cb);
@@ -76,7 +76,7 @@ describe('epson model profile', () => {
 
   it('defaults height to 1', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('TM-T20', connection);
+    const printer = await Printer.CONNECT('TM-T20', connection);
     const cb = jest.fn();
     const width = 6;
     await printer.withStyle({ width }, cb);
@@ -89,7 +89,7 @@ describe('epson model profile', () => {
 
   it('caps max char size at 8', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('TM-T20', connection);
+    const printer = await Printer.CONNECT('TM-T20', connection);
     const cb = jest.fn();
     await printer.withStyle(
       {
@@ -108,7 +108,7 @@ describe('epson model profile', () => {
 
   it('caps min char size at 1', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('TM-T20', connection);
+    const printer = await Printer.CONNECT('TM-T20', connection);
     const cb = jest.fn();
     await printer.withStyle(
       {

--- a/__tests__/profile/Epson.spec.ts
+++ b/__tests__/profile/Epson.spec.ts
@@ -18,7 +18,7 @@ describe('epson model profile', () => {
     const connection = new InMemory();
     const model = new Model('TM-T20');
     const printer = new Printer(model, connection);
-    printer.columns = 64;
+    printer.setColumns = 64;
     printer.writeln(
       'Large Text',
       Style.DoubleWidth + Style.DoubleHeight,

--- a/__tests__/profile/Epson.spec.ts
+++ b/__tests__/profile/Epson.spec.ts
@@ -1,6 +1,8 @@
 import Model from '../../src/Model';
 import InMemory from '../../src/connection/InMemory';
-import Printer, { Align, Style } from '../../src/Printer';
+import Printer from '../../src/Printer';
+import {Align} from "../../src/Align";
+import {Style} from "../../src/Style";
 import { load } from '../helper';
 
 describe('epson model profile', () => {

--- a/__tests__/profile/Epson.spec.ts
+++ b/__tests__/profile/Epson.spec.ts
@@ -1,14 +1,14 @@
 import Model from '../../src/Model';
 import InMemory from '../../src/connection/InMemory';
 import Printer from '../../src/Printer';
-import {Align} from "../../src/Align";
-import {Style} from "../../src/Style";
+import { Align } from '../../src/Align';
+import { Style } from '../../src/Style';
 import { load } from '../helper';
 
 describe('epson model profile', () => {
   it('write text from model TM-T20', async () => {
     const connection = new InMemory();
-    const model = await Model.initialise('TM-T20');
+    const model = 'TM-T20';
     const printer = await Printer.connect(model, connection);
     await printer.writeln('Large Text');
     expect(connection.buffer()).toStrictEqual(
@@ -18,7 +18,7 @@ describe('epson model profile', () => {
 
   it('write text with double width and height from model TM-T20', async () => {
     const connection = new InMemory();
-    const model = await Model.initialise('TM-T20');
+    const model = new Model('TM-T20');
     const printer = await Printer.connect(model, connection);
     await printer.setColumns(64);
     await printer.writeln(
@@ -36,10 +36,7 @@ describe('epson model profile', () => {
 
   it('draw qrcode from model TM-T20', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('TM-T20'),
-      connection,
-    );
+    const printer = await Printer.connect('TM-T20', connection);
     await printer.setAlignment(Align.Center);
     await printer.qrcode('https://github.com/grandchef/escpos-buffer');
     await printer.setAlignment(Align.Left);
@@ -50,10 +47,7 @@ describe('epson model profile', () => {
 
   it('sets char size from the style and clears it after', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('TM-T20'),
-      connection,
-    );
+    const printer = await Printer.connect('TM-T20', connection);
     const cb = jest.fn();
     const width = 4;
     const height = 6;
@@ -69,10 +63,7 @@ describe('epson model profile', () => {
 
   it('defaults width to 1', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('TM-T20'),
-      connection,
-    );
+    const printer = await Printer.connect('TM-T20', connection);
     const cb = jest.fn();
     const height = 6;
     await printer.withStyle({ height }, cb);
@@ -85,10 +76,7 @@ describe('epson model profile', () => {
 
   it('defaults height to 1', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('TM-T20'),
-      connection,
-    );
+    const printer = await Printer.connect('TM-T20', connection);
     const cb = jest.fn();
     const width = 6;
     await printer.withStyle({ width }, cb);
@@ -101,10 +89,7 @@ describe('epson model profile', () => {
 
   it('caps max char size at 8', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('TM-T20'),
-      connection,
-    );
+    const printer = await Printer.connect('TM-T20', connection);
     const cb = jest.fn();
     await printer.withStyle(
       {
@@ -123,10 +108,7 @@ describe('epson model profile', () => {
 
   it('caps min char size at 1', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('TM-T20'),
-      connection,
-    );
+    const printer = await Printer.connect('TM-T20', connection);
     const cb = jest.fn();
     await printer.withStyle(
       {

--- a/__tests__/profile/Epson.spec.ts
+++ b/__tests__/profile/Epson.spec.ts
@@ -4,28 +4,28 @@ import Printer, { Align, Style } from '../../src/Printer';
 import { load } from '../helper';
 
 describe('epson model profile', () => {
-  it('write text from model TM-T20', () => {
+  it('write text from model TM-T20', async () => {
     const connection = new InMemory();
-    const model = new Model('TM-T20');
-    const printer = new Printer(model, connection);
-    printer.writeln('Large Text');
+    const model = await Model.initialise('TM-T20');
+    const printer = await Printer.connect(model, connection);
+    await printer.writeln('Large Text');
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_text', connection.buffer()),
     );
   });
 
-  it('write text with double width and height from model TM-T20', () => {
+  it('write text with double width and height from model TM-T20', async () => {
     const connection = new InMemory();
-    const model = new Model('TM-T20');
-    const printer = new Printer(model, connection);
-    printer.setColumns = 64;
-    printer.writeln(
+    const model = await Model.initialise('TM-T20');
+    const printer = await Printer.connect(model, connection);
+    await printer.setColumns(64);
+    await printer.writeln(
       'Large Text',
       Style.DoubleWidth + Style.DoubleHeight,
       Align.Center,
     );
-    printer.feed(2);
-    printer.feed(255);
+    await printer.feed(2);
+    await printer.feed(255);
     expect(model.profile.font.name).toBe('Font B');
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_large_text_font', connection.buffer()),
@@ -34,22 +34,28 @@ describe('epson model profile', () => {
 
   it('draw qrcode from model TM-T20', async () => {
     const connection = new InMemory();
-    const printer = new Printer(new Model('TM-T20'), connection);
-    printer.alignment = Align.Center;
+    const printer = await Printer.connect(
+      await Model.initialise('TM-T20'),
+      connection,
+    );
+    await printer.setAlignment(Align.Center);
     await printer.qrcode('https://github.com/grandchef/escpos-buffer');
-    printer.alignment = Align.Left;
+    await printer.setAlignment(Align.Left);
     expect(connection.buffer()).toStrictEqual(
       load('tm-t20_qrcode', connection.buffer()),
     );
   });
 
-  it('sets char size from the style and clears it after', () => {
+  it('sets char size from the style and clears it after', async () => {
     const connection = new InMemory();
-    const printer = new Printer(new Model('TM-T20'), connection);
+    const printer = await Printer.connect(
+      await Model.initialise('TM-T20'),
+      connection,
+    );
     const cb = jest.fn();
     const width = 4;
     const height = 6;
-    printer.withStyle({ width, height }, cb);
+    await printer.withStyle({ width, height }, cb);
     const expectedN = (height - 1) | ((width - 1) << 4);
 
     const buffer = connection.buffer();
@@ -59,12 +65,15 @@ describe('epson model profile', () => {
     expect(clearCharSizeCmd).toEqual([0x1d, 0x21, 0x00]);
   });
 
-  it('defaults width to 1', () => {
+  it('defaults width to 1', async () => {
     const connection = new InMemory();
-    const printer = new Printer(new Model('TM-T20'), connection);
+    const printer = await Printer.connect(
+      await Model.initialise('TM-T20'),
+      connection,
+    );
     const cb = jest.fn();
     const height = 6;
-    printer.withStyle({ height }, cb);
+    await printer.withStyle({ height }, cb);
 
     const expectedWidth = 1;
     const expectedN = (height - 1) | ((expectedWidth - 1) << 4);
@@ -72,12 +81,15 @@ describe('epson model profile', () => {
     expect(buffer[5]).toBe(expectedN);
   });
 
-  it('defaults height to 1', () => {
+  it('defaults height to 1', async () => {
     const connection = new InMemory();
-    const printer = new Printer(new Model('TM-T20'), connection);
+    const printer = await Printer.connect(
+      await Model.initialise('TM-T20'),
+      connection,
+    );
     const cb = jest.fn();
     const width = 6;
-    printer.withStyle({ width }, cb);
+    await printer.withStyle({ width }, cb);
 
     const expectedHeight = 1;
     const expectedN = (expectedHeight - 1) | ((width - 1) << 4);
@@ -85,11 +97,14 @@ describe('epson model profile', () => {
     expect(buffer[5]).toBe(expectedN);
   });
 
-  it('caps max char size at 8', () => {
+  it('caps max char size at 8', async () => {
     const connection = new InMemory();
-    const printer = new Printer(new Model('TM-T20'), connection);
+    const printer = await Printer.connect(
+      await Model.initialise('TM-T20'),
+      connection,
+    );
     const cb = jest.fn();
-    printer.withStyle(
+    await printer.withStyle(
       {
         width: 15,
         height: 10,
@@ -104,11 +119,14 @@ describe('epson model profile', () => {
     expect(buffer[5]).toBe(expectedN);
   });
 
-  it('caps min char size at 1', () => {
+  it('caps min char size at 1', async () => {
     const connection = new InMemory();
-    const printer = new Printer(new Model('TM-T20'), connection);
+    const printer = await Printer.connect(
+      await Model.initialise('TM-T20'),
+      connection,
+    );
     const cb = jest.fn();
-    printer.withStyle(
+    await printer.withStyle(
       {
         width: -1,
         height: -1,

--- a/__tests__/profile/Generic.spec.ts
+++ b/__tests__/profile/Generic.spec.ts
@@ -3,7 +3,7 @@ import InMemory from '../../src/connection/InMemory';
 import Printer, { Align, Style } from '../../src/Printer';
 import { load } from '../helper';
 
-describe('generic model profile', async () => {
+describe('generic model profile', () => {
   it('write line text from model CMP-20', async () => {
     const connection = new InMemory();
     const printer = await Printer.connect(

--- a/__tests__/profile/Generic.spec.ts
+++ b/__tests__/profile/Generic.spec.ts
@@ -1,6 +1,8 @@
 import Model from '../../src/Model';
 import InMemory from '../../src/connection/InMemory';
-import Printer, { Align, Style } from '../../src/Printer';
+import Printer from '../../src/Printer';
+import {Align} from "../../src/Align";
+import {Style} from "../../src/Style";
 import { load } from '../helper';
 
 describe('generic model profile', () => {

--- a/__tests__/profile/Generic.spec.ts
+++ b/__tests__/profile/Generic.spec.ts
@@ -7,7 +7,7 @@ import { load } from '../helper';
 describe('generic model profile', () => {
   it('write line text from model CMP-20', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('CMP-20', connection);
+    const printer = await Printer.CONNECT('CMP-20', connection);
     await printer.writeln('Large Text');
     expect(connection.buffer()).toStrictEqual(
       load('cmp-20_text_line', connection.buffer()),
@@ -16,7 +16,7 @@ describe('generic model profile', () => {
 
   it('write text with double width and height from model CMP-20', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('CMP-20', connection);
+    const printer = await Printer.CONNECT('CMP-20', connection);
     await printer.writeln(
       'Large Text',
       Style.DoubleWidth + Style.DoubleHeight,
@@ -29,7 +29,7 @@ describe('generic model profile', () => {
 
   it('write text with double width and height from Generic 80mm', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('POS-80', connection);
+    const printer = await Printer.CONNECT('POS-80', connection);
     await printer.writeln(
       'Large Text',
       Style.DoubleWidth + Style.DoubleHeight,
@@ -42,7 +42,7 @@ describe('generic model profile', () => {
 
   it('draw qrcode from model CMP-20', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('CMP-20', connection);
+    const printer = await Printer.CONNECT('CMP-20', connection);
     await printer.setAlignment(Align.Center);
     await printer.qrcode('https://github.com/grandchef/escpos-buffer');
     await printer.setAlignment(Align.Left);

--- a/__tests__/profile/Generic.spec.ts
+++ b/__tests__/profile/Generic.spec.ts
@@ -1,17 +1,13 @@
-import Model from '../../src/Model';
 import InMemory from '../../src/connection/InMemory';
 import Printer from '../../src/Printer';
-import {Align} from "../../src/Align";
-import {Style} from "../../src/Style";
+import { Align } from '../../src/Align';
+import { Style } from '../../src/Style';
 import { load } from '../helper';
 
 describe('generic model profile', () => {
   it('write line text from model CMP-20', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('CMP-20'),
-      connection,
-    );
+    const printer = await Printer.connect('CMP-20', connection);
     await printer.writeln('Large Text');
     expect(connection.buffer()).toStrictEqual(
       load('cmp-20_text_line', connection.buffer()),
@@ -20,10 +16,7 @@ describe('generic model profile', () => {
 
   it('write text with double width and height from model CMP-20', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('CMP-20'),
-      connection,
-    );
+    const printer = await Printer.connect('CMP-20', connection);
     await printer.writeln(
       'Large Text',
       Style.DoubleWidth + Style.DoubleHeight,
@@ -36,10 +29,7 @@ describe('generic model profile', () => {
 
   it('write text with double width and height from Generic 80mm', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('POS-80'),
-      connection,
-    );
+    const printer = await Printer.connect('POS-80', connection);
     await printer.writeln(
       'Large Text',
       Style.DoubleWidth + Style.DoubleHeight,
@@ -52,10 +42,7 @@ describe('generic model profile', () => {
 
   it('draw qrcode from model CMP-20', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('CMP-20'),
-      connection,
-    );
+    const printer = await Printer.connect('CMP-20', connection);
     await printer.setAlignment(Align.Center);
     await printer.qrcode('https://github.com/grandchef/escpos-buffer');
     await printer.setAlignment(Align.Left);

--- a/__tests__/profile/Generic.spec.ts
+++ b/__tests__/profile/Generic.spec.ts
@@ -1,36 +1,64 @@
-import Model from '../../src/Model'
-import InMemory from '../../src/connection/InMemory'
-import Printer, { Align, Style } from '../../src/Printer'
-import { load } from '../helper'
+import Model from '../../src/Model';
+import InMemory from '../../src/connection/InMemory';
+import Printer, { Align, Style } from '../../src/Printer';
+import { load } from '../helper';
 
-describe('generic model profile', () => {
-  it('write line text from model CMP-20', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('CMP-20'), connection)
-    printer.writeln('Large Text')
-    expect(connection.buffer()).toStrictEqual(load('cmp-20_text_line', connection.buffer()))
-  })
+describe('generic model profile', async () => {
+  it('write line text from model CMP-20', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('CMP-20'),
+      connection,
+    );
+    await printer.writeln('Large Text');
+    expect(connection.buffer()).toStrictEqual(
+      load('cmp-20_text_line', connection.buffer()),
+    );
+  });
 
-  it('write text with double width and height from model CMP-20', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('CMP-20'), connection)
-    printer.writeln('Large Text', Style.DoubleWidth + Style.DoubleHeight, Align.Center)
-    expect(connection.buffer()).toStrictEqual(load('cmp-20_large_text', connection.buffer()))
-  })
+  it('write text with double width and height from model CMP-20', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('CMP-20'),
+      connection,
+    );
+    await printer.writeln(
+      'Large Text',
+      Style.DoubleWidth + Style.DoubleHeight,
+      Align.Center,
+    );
+    expect(connection.buffer()).toStrictEqual(
+      load('cmp-20_large_text', connection.buffer()),
+    );
+  });
 
-  it('write text with double width and height from Generic 80mm', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('POS-80'), connection)
-    printer.writeln('Large Text', Style.DoubleWidth + Style.DoubleHeight, Align.Center)
-    expect(connection.buffer()).toStrictEqual(load('generic-80mm_large_text', connection.buffer()))
-  })
+  it('write text with double width and height from Generic 80mm', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('POS-80'),
+      connection,
+    );
+    await printer.writeln(
+      'Large Text',
+      Style.DoubleWidth + Style.DoubleHeight,
+      Align.Center,
+    );
+    expect(connection.buffer()).toStrictEqual(
+      load('generic-80mm_large_text', connection.buffer()),
+    );
+  });
 
   it('draw qrcode from model CMP-20', async () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('CMP-20'), connection)
-    printer.alignment = Align.Center
-    await printer.qrcode('https://github.com/grandchef/escpos-buffer')
-    printer.alignment = Align.Left
-    expect(connection.buffer()).toStrictEqual(load('cmp-20_qrcode', connection.buffer()))
-  })
-})
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('CMP-20'),
+      connection,
+    );
+    await printer.setAlignment(Align.Center);
+    await printer.qrcode('https://github.com/grandchef/escpos-buffer');
+    await printer.setAlignment(Align.Left);
+    expect(connection.buffer()).toStrictEqual(
+      load('cmp-20_qrcode', connection.buffer()),
+    );
+  });
+});

--- a/__tests__/profile/Perto.spec.ts
+++ b/__tests__/profile/Perto.spec.ts
@@ -1,21 +1,31 @@
-import Model from '../../src/Model'
-import InMemory from '../../src/connection/InMemory'
-import Printer, { Align } from '../../src/Printer'
-import { load } from '../helper'
+import Model from '../../src/Model';
+import InMemory from '../../src/connection/InMemory';
+import Printer, { Align } from '../../src/Printer';
+import { load } from '../helper';
 
 describe('perto model profile', () => {
-  it('emit buzzer from model PertoPrinter', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('PertoPrinter'), connection)
-    printer.buzzer()
-    expect(connection.buffer()).toStrictEqual(load('perto_printer_buzzer', connection.buffer()))
-  })
+  it('emit buzzer from model PertoPrinter', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('PertoPrinter'),
+      connection,
+    );
+    await printer.buzzer();
+    expect(connection.buffer()).toStrictEqual(
+      load('perto_printer_buzzer', connection.buffer()),
+    );
+  });
 
-  it('cut paper from model PertoPrinter', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('PertoPrinter'), connection)
-    printer.writeln('Cut below', 0, Align.Center)
-    printer.cutter()
-    expect(connection.buffer()).toStrictEqual(load('perto_printer_cutter', connection.buffer()))
-  })
-})
+  it('cut paper from model PertoPrinter', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('PertoPrinter'),
+      connection,
+    );
+    await printer.writeln('Cut below', 0, Align.Center);
+    await printer.cutter();
+    expect(connection.buffer()).toStrictEqual(
+      load('perto_printer_cutter', connection.buffer()),
+    );
+  });
+});

--- a/__tests__/profile/Perto.spec.ts
+++ b/__tests__/profile/Perto.spec.ts
@@ -6,7 +6,7 @@ import { load } from '../helper';
 describe('perto model profile', () => {
   it('emit buzzer from model PertoPrinter', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('PertoPrinter', connection);
+    const printer = await Printer.CONNECT('PertoPrinter', connection);
     await printer.buzzer();
     expect(connection.buffer()).toStrictEqual(
       load('perto_printer_buzzer', connection.buffer()),
@@ -15,7 +15,7 @@ describe('perto model profile', () => {
 
   it('cut paper from model PertoPrinter', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('PertoPrinter', connection);
+    const printer = await Printer.CONNECT('PertoPrinter', connection);
     await printer.writeln('Cut below', 0, Align.Center);
     await printer.cutter();
     expect(connection.buffer()).toStrictEqual(

--- a/__tests__/profile/Perto.spec.ts
+++ b/__tests__/profile/Perto.spec.ts
@@ -1,16 +1,12 @@
-import Model from '../../src/Model';
 import InMemory from '../../src/connection/InMemory';
 import Printer from '../../src/Printer';
-import {Align} from "../../src/Align";
+import { Align } from '../../src/Align';
 import { load } from '../helper';
 
 describe('perto model profile', () => {
   it('emit buzzer from model PertoPrinter', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('PertoPrinter'),
-      connection,
-    );
+    const printer = await Printer.connect('PertoPrinter', connection);
     await printer.buzzer();
     expect(connection.buffer()).toStrictEqual(
       load('perto_printer_buzzer', connection.buffer()),
@@ -19,10 +15,7 @@ describe('perto model profile', () => {
 
   it('cut paper from model PertoPrinter', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('PertoPrinter'),
-      connection,
-    );
+    const printer = await Printer.connect('PertoPrinter', connection);
     await printer.writeln('Cut below', 0, Align.Center);
     await printer.cutter();
     expect(connection.buffer()).toStrictEqual(

--- a/__tests__/profile/Perto.spec.ts
+++ b/__tests__/profile/Perto.spec.ts
@@ -1,6 +1,7 @@
 import Model from '../../src/Model';
 import InMemory from '../../src/connection/InMemory';
-import Printer, { Align } from '../../src/Printer';
+import Printer from '../../src/Printer';
+import {Align} from "../../src/Align";
 import { load } from '../helper';
 
 describe('perto model profile', () => {

--- a/__tests__/profile/Sweda.spec.ts
+++ b/__tests__/profile/Sweda.spec.ts
@@ -5,7 +5,7 @@ import { load } from '../helper';
 describe('sweda model profile', () => {
   it('emit buzzer from model SI-300L', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect('SI-300L', connection);
+    const printer = await Printer.CONNECT('SI-300L', connection);
     printer.buzzer();
     expect(connection.buffer()).toStrictEqual(
       load('si-300l_buzzer', connection.buffer()),

--- a/__tests__/profile/Sweda.spec.ts
+++ b/__tests__/profile/Sweda.spec.ts
@@ -1,4 +1,3 @@
-import Model from '../../src/Model';
 import InMemory from '../../src/connection/InMemory';
 import Printer from '../../src/Printer';
 import { load } from '../helper';
@@ -6,10 +5,7 @@ import { load } from '../helper';
 describe('sweda model profile', () => {
   it('emit buzzer from model SI-300L', async () => {
     const connection = new InMemory();
-    const printer = await Printer.connect(
-      await Model.initialise('SI-300L'),
-      connection,
-    );
+    const printer = await Printer.connect('SI-300L', connection);
     printer.buzzer();
     expect(connection.buffer()).toStrictEqual(
       load('si-300l_buzzer', connection.buffer()),

--- a/__tests__/profile/Sweda.spec.ts
+++ b/__tests__/profile/Sweda.spec.ts
@@ -1,13 +1,18 @@
-import Model from '../../src/Model'
-import InMemory from '../../src/connection/InMemory'
-import Printer from '../../src/Printer'
-import { load } from '../helper'
+import Model from '../../src/Model';
+import InMemory from '../../src/connection/InMemory';
+import Printer from '../../src/Printer';
+import { load } from '../helper';
 
 describe('sweda model profile', () => {
-  it('emit buzzer from model SI-300L', () => {
-    const connection = new InMemory()
-    const printer = new Printer(new Model('SI-300L'), connection)
-    printer.buzzer()
-    expect(connection.buffer()).toStrictEqual(load('si-300l_buzzer', connection.buffer()))
-  })
-})
+  it('emit buzzer from model SI-300L', async () => {
+    const connection = new InMemory();
+    const printer = await Printer.connect(
+      await Model.initialise('SI-300L'),
+      connection,
+    );
+    printer.buzzer();
+    expect(connection.buffer()).toStrictEqual(
+      load('si-300l_buzzer', connection.buffer()),
+    );
+  });
+});

--- a/__tests__/profile/index.spec.ts
+++ b/__tests__/profile/index.spec.ts
@@ -14,15 +14,15 @@ class MockProfile extends Profile {
     number: Drawer,
     on_time: number,
     off_time: number,
-  ) => void = jest.fn();
+  ) => Promise<void> = jest.fn();
   qrcode: (data: string, size: number) => Promise<void> = jest.fn();
-  setMode: (mode: number, enable: boolean) => void = jest.fn();
-  setStyle: (style: Style, enable: boolean) => void = jest.fn();
-  setStyles: (styles: number, enable: boolean) => void = jest.fn();
+  setMode: (mode: number, enable: boolean) => Promise<void> = jest.fn();
+  setStyle: (style: Style, enable: boolean) => Promise<void> = jest.fn();
+  setStyles: (styles: number, enable: boolean) => Promise<void> = jest.fn();
   setCharSize: (charSize: {
     width: number;
     height: number;
-  }) => void = jest.fn();
+  }) => Promise<void> = jest.fn();
 }
 const capability: Capability = {
   columns: 42,

--- a/__tests__/profile/index.spec.ts
+++ b/__tests__/profile/index.spec.ts
@@ -3,10 +3,10 @@ import { Capability } from '../../src/capabilities';
 import { Style, Align, Cut, Drawer } from '../../src';
 
 class MockProfile extends Profile {
-  get setAlignment() {
+  get Alignment() {
     return null;
   }
-  set setAlignment(_: number) {}
+  setAlignment: (_: number) => Promise<void> = jest.fn();
   feed: (lines: number) => Promise<void> = jest.fn();
   cutter: (mode: Cut) => Promise<void> = jest.fn();
   buzzer: () => Promise<void> = jest.fn();
@@ -47,7 +47,7 @@ const capability: Capability = {
 describe('Profile', () => {
   afterEach(() => jest.resetAllMocks());
   describe('withStyle', () => {
-    it('should apply font size and then unapply it after calling the callback', () => {
+    it('should apply font size and then unapply it after calling the callback', async () => {
       const profile = new MockProfile(capability);
       const styleConf = {
         width: 4,
@@ -55,14 +55,14 @@ describe('Profile', () => {
       };
       const cb = jest.fn();
 
-      profile.withStyle(styleConf, cb);
+      await profile.withStyle(styleConf, cb);
 
       expect(profile.setCharSize).toHaveBeenCalledWith({ ...styleConf });
       expect(cb).toHaveBeenCalledTimes(1);
       expect(profile.setCharSize).toHaveBeenCalledWith({ width: 1, height: 1 });
     });
 
-    it('should apply style and then unapply it after calling the callback', () => {
+    it('should apply style and then unapply it after calling the callback', async () => {
       const profile = new MockProfile(capability);
       const styleConf = {
         bold: true,
@@ -71,7 +71,7 @@ describe('Profile', () => {
       };
       const cb = jest.fn();
 
-      profile.withStyle(styleConf, cb);
+      await profile.withStyle(styleConf, cb);
 
       const expectedStyles = Style.Bold | Style.Italic | Style.Underline;
 
@@ -80,16 +80,16 @@ describe('Profile', () => {
       expect(profile.setStyles).toHaveBeenCalledWith(expectedStyles, false);
     });
 
-    it('should apply alignment and then unapply it after calling the callback', () => {
+    it('should apply alignment and then unapply it after calling the callback', async () => {
       const profile = new MockProfile(capability);
-      const alignmentSetter = jest.spyOn(profile, 'alignment', 'set');
+      const alignmentSetter = jest.spyOn(profile, 'setAlignment');
       const align = Align.Center;
       const styleConf = {
         align,
       };
       const cb = jest.fn();
 
-      profile.withStyle(styleConf, cb);
+      await profile.withStyle(styleConf, cb);
 
       expect(alignmentSetter).toHaveBeenCalledWith(align);
       expect(cb).toHaveBeenCalledTimes(1);

--- a/__tests__/profile/index.spec.ts
+++ b/__tests__/profile/index.spec.ts
@@ -3,10 +3,10 @@ import { Capability } from '../../src/capabilities';
 import { Style, Align, Cut, Drawer } from '../../src';
 
 class MockProfile extends Profile {
-  get alignment() {
+  get setAlignment() {
     return null;
   }
-  set alignment(_: number) {}
+  set setAlignment(_: number) {}
   feed: (lines: number) => Promise<void> = jest.fn();
   cutter: (mode: Cut) => Promise<void> = jest.fn();
   buzzer: () => Promise<void> = jest.fn();

--- a/__tests__/profile/index.spec.ts
+++ b/__tests__/profile/index.spec.ts
@@ -1,9 +1,9 @@
 import { Profile } from '../../src/profile';
 import { Capability } from '../../src/capabilities';
-import {Align} from "../../src/Align";
-import {Style} from "../../src/Style";
-import {Cut} from "../../src/Cut";
-import {Drawer} from "../../src/Drawer";
+import { Align } from '../../src/Align';
+import { Style } from '../../src/Style';
+import { Cut } from '../../src/Cut';
+import { Drawer } from '../../src/Drawer';
 
 class MockProfile extends Profile {
   get Alignment() {

--- a/__tests__/profile/index.spec.ts
+++ b/__tests__/profile/index.spec.ts
@@ -1,6 +1,9 @@
 import { Profile } from '../../src/profile';
 import { Capability } from '../../src/capabilities';
-import { Style, Align, Cut, Drawer } from '../../src';
+import {Align} from "../../src/Align";
+import {Style} from "../../src/Style";
+import {Cut} from "../../src/Cut";
+import {Drawer} from "../../src/Drawer";
 
 class MockProfile extends Profile {
   get Alignment() {

--- a/__tests__/profile/index.spec.ts
+++ b/__tests__/profile/index.spec.ts
@@ -7,15 +7,22 @@ class MockProfile extends Profile {
     return null;
   }
   set alignment(_: number) {}
-  feed: (lines: number) => void = jest.fn();
-  cutter: (mode: Cut) => void = jest.fn();
-  buzzer: () => void = jest.fn();
-  drawer: (number: Drawer, on_time: number, off_time: number) => void = jest.fn();
+  feed: (lines: number) => Promise<void> = jest.fn();
+  cutter: (mode: Cut) => Promise<void> = jest.fn();
+  buzzer: () => Promise<void> = jest.fn();
+  drawer: (
+    number: Drawer,
+    on_time: number,
+    off_time: number,
+  ) => void = jest.fn();
   qrcode: (data: string, size: number) => Promise<void> = jest.fn();
   setMode: (mode: number, enable: boolean) => void = jest.fn();
   setStyle: (style: Style, enable: boolean) => void = jest.fn();
   setStyles: (styles: number, enable: boolean) => void = jest.fn();
-  setCharSize: (charSize: { width: number, height: number }) => void = jest.fn();
+  setCharSize: (charSize: {
+    width: number;
+    height: number;
+  }) => void = jest.fn();
 }
 const capability: Capability = {
   columns: 42,

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,4 +17,9 @@ module.exports = {
     'src/**/*.{ts,tsx,js,jsx}',
     '!src/**/*.d.ts',
   ],
+  globals: {
+    'ts-jest': {
+      diagnostics: false
+    }
+  }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "escpos-buffer",
-  "version": "1.6.6",
+  "version": "2.0.0",
   "description": "Library to generate buffer for thermal printers.",
   "author": "GrandChef Team <desenvolvimento@grandchef.com.br>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/node": "^12.12.5",
     "@types/w3c-web-usb": "1.0.4",
     "jest": "~24.9.0",
-    "prettier": "~1.18.2",
+    "prettier": "~1.19.0",
     "rimraf": "^3.0.0",
     "ts-jest": "^24.1.0",
     "tslint": "~5.20.1",

--- a/src/Align.ts
+++ b/src/Align.ts
@@ -1,0 +1,6 @@
+export enum Align {
+  Left,
+  Center,
+  Right
+}
+

--- a/src/Align.ts
+++ b/src/Align.ts
@@ -1,6 +1,5 @@
 export enum Align {
   Left,
   Center,
-  Right
+  Right,
 }
-

--- a/src/Cut.ts
+++ b/src/Cut.ts
@@ -1,0 +1,5 @@
+export enum Cut {
+  Full,
+  Partial
+}
+

--- a/src/Cut.ts
+++ b/src/Cut.ts
@@ -1,5 +1,4 @@
 export enum Cut {
   Full,
-  Partial
+  Partial,
 }
-

--- a/src/Drawer.ts
+++ b/src/Drawer.ts
@@ -1,5 +1,4 @@
 export enum Drawer {
   First,
-  Second
+  Second,
 }
-

--- a/src/Drawer.ts
+++ b/src/Drawer.ts
@@ -1,0 +1,5 @@
+export enum Drawer {
+  First,
+  Second
+}
+

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -16,36 +16,41 @@ const cache = new Map<string, Capability>();
 export default class Model {
   private _profile: Profile;
 
-  constructor(model: string | Profile) {
-    if (typeof model === 'string') {
-      this._profile = this.instance(Model.EXPAND(Model.FIND(model)));
-    } else {
-      this._profile = model;
-    }
+  static async initialise(model: string) {
+    const profile = await Model.initialiseProfile(
+      Model.EXPAND(Model.FIND(model)),
+    );
+    return new Model(profile);
   }
 
-  instance(capability: Capability): Profile {
+  constructor(model: Profile) {
+    this._profile = model;
+  }
+
+  private static async initialiseProfile(
+    capability: Capability,
+  ): Promise<Profile> {
     switch (capability.profile) {
       case 'bematech':
-        return new Bematech(capability);
+        return Profile.initialise(Bematech, capability);
       case 'controlid':
-        return new ControliD(capability);
+        return Profile.initialise(ControliD, capability);
       case 'daruma':
-        return new Daruma(capability);
+        return Profile.initialise(Daruma, capability);
       case 'dataregis':
-        return new Dataregis(capability);
+        return Profile.initialise(Dataregis, capability);
       case 'diebold':
-        return new Diebold(capability);
+        return Profile.initialise(Diebold, capability);
       case 'elgin':
-        return new Elgin(capability);
+        return Profile.initialise(Elgin, capability);
       case 'generic':
-        return new Generic(capability);
+        return Profile.initialise(Generic, capability);
       case 'perto':
-        return new Perto(capability);
+        return Profile.initialise(Perto, capability);
       case 'sweda':
-        return new Sweda(capability);
+        return Profile.initialise(Sweda, capability);
       default:
-        return new Epson(capability);
+        return Profile.initialise(Epson, capability);
     }
   }
 

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -16,10 +16,6 @@ const cache = new Map<string, Capability>();
 export default class Model {
   private _profile: Profile;
 
-  static initialise(model: SupportedModel) {
-    return new Model(model);
-  }
-
   constructor(model: Profile | SupportedModel) {
     if (typeof model === 'string') {
       this._profile = Model.initialiseProfile(Model.EXPAND(Model.FIND(model)));

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -1,5 +1,5 @@
 import { Profile } from './profile';
-import capabilities, { Capability } from './capabilities';
+import capabilities, { Capability, SupportedModel } from './capabilities';
 import Bematech from './profile/Bematech';
 import Epson from './profile/Epson';
 import ControliD from './profile/ControliD';
@@ -16,41 +16,41 @@ const cache = new Map<string, Capability>();
 export default class Model {
   private _profile: Profile;
 
-  static async initialise(model: string) {
-    const profile = await Model.initialiseProfile(
-      Model.EXPAND(Model.FIND(model)),
-    );
-    return new Model(profile);
+  static initialise(model: SupportedModel) {
+    return new Model(model);
   }
 
-  constructor(model: Profile) {
-    this._profile = model;
+  constructor(model: Profile | SupportedModel) {
+    if (typeof model === 'string') {
+      this._profile = Model.initialiseProfile(Model.EXPAND(Model.FIND(model)));
+    } else {
+      console.log('theo-27671');
+      this._profile = model;
+    }
   }
 
-  private static async initialiseProfile(
-    capability: Capability,
-  ): Promise<Profile> {
+  private static initialiseProfile(capability: Capability): Profile {
     switch (capability.profile) {
       case 'bematech':
-        return Profile.initialise(Bematech, capability);
+        return new Bematech(capability);
       case 'controlid':
-        return Profile.initialise(ControliD, capability);
+        return new ControliD(capability);
       case 'daruma':
-        return Profile.initialise(Daruma, capability);
+        return new Daruma(capability);
       case 'dataregis':
-        return Profile.initialise(Dataregis, capability);
+        return new Dataregis(capability);
       case 'diebold':
-        return Profile.initialise(Diebold, capability);
+        return new Diebold(capability);
       case 'elgin':
-        return Profile.initialise(Elgin, capability);
+        return new Elgin(capability);
       case 'generic':
-        return Profile.initialise(Generic, capability);
+        return new Generic(capability);
       case 'perto':
-        return Profile.initialise(Perto, capability);
+        return new Perto(capability);
       case 'sweda':
-        return Profile.initialise(Sweda, capability);
+        return new Sweda(capability);
       default:
-        return Profile.initialise(Epson, capability);
+        return new Epson(capability);
     }
   }
 

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -24,7 +24,6 @@ export default class Model {
     if (typeof model === 'string') {
       this._profile = Model.initialiseProfile(Model.EXPAND(Model.FIND(model)));
     } else {
-      console.log('theo-27671');
       this._profile = model;
     }
   }

--- a/src/Printer.ts
+++ b/src/Printer.ts
@@ -5,7 +5,7 @@ import { StyleConf } from './profile';
 import { Drawer } from './Drawer';
 import { Cut } from './Cut';
 import { Align } from './Align';
-import {SupportedModel} from './capabilities';
+import { SupportedModel } from './capabilities';
 
 export default class Printer {
   private model: Model;
@@ -87,11 +87,11 @@ export default class Printer {
     _model: SupportedModel | Model,
     connection: Connection,
   ): Promise<Printer> {
-    let model: Model
-    if(typeof _model === 'string') {
-      model = new Model(_model)
+    let model: Model;
+    if (typeof _model === 'string') {
+      model = new Model(_model);
     } else {
-      model = _model
+      model = _model;
     }
     await connection.open();
     model.profile.connection = connection;

--- a/src/Printer.ts
+++ b/src/Printer.ts
@@ -107,8 +107,8 @@ export default class Printer {
     return this.model.profile.columns;
   }
 
-  set columns(value: number) {
-    this.model.profile.columns = value;
+  async setColumns(value: number) {
+    return this.model.profile.setColumns(value);
   }
 
   async close() {

--- a/src/Printer.ts
+++ b/src/Printer.ts
@@ -42,12 +42,12 @@ export default class Printer {
     this.model.profile.codepage = value;
   }
 
-  buzzer() {
-    this.model.profile.buzzer();
+  async buzzer() {
+    return this.model.profile.buzzer();
   }
 
-  cutter(mode: Cut = Cut.Partial) {
-    this.model.profile.cutter(mode);
+  async cutter(mode: Cut = Cut.Partial) {
+    return this.model.profile.cutter(mode);
   }
 
   /**
@@ -55,12 +55,12 @@ export default class Printer {
    * @param on_time time in milliseconds that activate the drawer
    * @param off_time time in milliseconds that deactivate the drawer
    */
-  drawer(
+  async drawer(
     number: Drawer = Drawer.First,
     on_time: number = 120,
     off_time: number = 240,
   ) {
-    this.model.profile.drawer(number, on_time, off_time);
+    return this.model.profile.drawer(number, on_time, off_time);
   }
 
   async draw(image: Image) {
@@ -68,7 +68,7 @@ export default class Printer {
   }
 
   async qrcode(data: string, size: number = null) {
-    await this.model.profile.qrcode(data, size);
+    return this.model.profile.qrcode(data, size);
   }
 
   set alignment(align: Align) {
@@ -79,12 +79,16 @@ export default class Printer {
     return this.model.profile.write(text, styles);
   }
 
-  writeln(text: string = '', styles: number = 0, align: Align = Align.Left) {
-    this.model.profile.writeln(text, styles, align);
+  async writeln(
+    text: string = '',
+    styles: number = 0,
+    align: Align = Align.Left,
+  ) {
+    return this.model.profile.writeln(text, styles, align);
   }
 
-  withStyle(styleConf: StyleConf, cb: Function) {
-    this.model.profile.withStyle(styleConf, cb);
+  async withStyle(styleConf: StyleConf, cb: Function) {
+    return this.model.profile.withStyle(styleConf, cb);
   }
 
   async feed(lines: number = 1) {
@@ -99,7 +103,7 @@ export default class Printer {
     this.model.profile.columns = value;
   }
 
-  close() {
-    this.model.profile.finalize();
+  async close() {
+    return this.model.profile.finalize();
   }
 }

--- a/src/Printer.ts
+++ b/src/Printer.ts
@@ -63,8 +63,8 @@ export default class Printer {
     this.model.profile.drawer(number, on_time, off_time);
   }
 
-  draw(image: Image) {
-    this.model.profile.draw(image);
+  async draw(image: Image) {
+    return this.model.profile.draw(image);
   }
 
   async qrcode(data: string, size: number = null) {
@@ -75,8 +75,8 @@ export default class Printer {
     this.model.profile.alignment = align;
   }
 
-  write(text: string, styles: number = 0) {
-    this.model.profile.write(text, styles);
+  async write(text: string, styles: number = 0) {
+    return this.model.profile.write(text, styles);
   }
 
   writeln(text: string = '', styles: number = 0, align: Align = Align.Left) {
@@ -87,8 +87,8 @@ export default class Printer {
     this.model.profile.withStyle(styleConf, cb);
   }
 
-  feed(lines: number = 1) {
-    this.model.profile.feed(lines);
+  async feed(lines: number = 1) {
+    return this.model.profile.feed(lines);
   }
 
   get columns(): number {

--- a/src/Printer.ts
+++ b/src/Printer.ts
@@ -31,15 +31,23 @@ export enum Drawer {
 export default class Printer {
   private model: Model;
 
-  constructor(model: Model, connection: Connection) {
-    connection.open();
-    this.model = model;
-    this.model.profile.connection = connection;
-    this.model.profile.initialize();
+  static async connectPrinter(
+    model: Model,
+    connection: Connection,
+  ): Promise<Printer> {
+    await connection.open();
+    const printer = new Printer(model, connection);
+    await model.profile.initialize();
+    return printer;
   }
 
-  set codepage(value: string) {
-    this.model.profile.codepage = value;
+  constructor(model: Model, connection: Connection) {
+    this.model = model;
+    this.model.profile.connection = connection;
+  }
+
+  async setCodepage(value: string) {
+    return this.model.profile.setCodepage(value);
   }
 
   async buzzer() {

--- a/src/Printer.ts
+++ b/src/Printer.ts
@@ -2,48 +2,16 @@ import Model from './Model';
 import { Connection } from './connection';
 import Image from './graphics/Image';
 import { StyleConf } from './profile';
-
-export enum Align {
-  Left,
-  Center,
-  Right,
-}
-
-export enum Style {
-  Bold = 1,
-  Italic = 2,
-  Underline = 4,
-  Condensed = 8,
-  DoubleWidth = 16,
-  DoubleHeight = 32,
-}
-
-export enum Cut {
-  Full,
-  Partial,
-}
-
-export enum Drawer {
-  First,
-  Second,
-}
+import { Drawer } from './Drawer';
+import { Cut } from './Cut';
+import { Align } from './Align';
+import {SupportedModel} from './capabilities';
 
 export default class Printer {
   private model: Model;
 
-  static async connect(
-    model: Model,
-    connection: Connection,
-  ): Promise<Printer> {
-    await connection.open();
-    const printer = new Printer(model, connection);
-    await model.profile.initialize();
-    return printer;
-  }
-
-  constructor(model: Model, connection: Connection) {
+  constructor(model: Model) {
     this.model = model;
-    this.model.profile.connection = connection;
   }
 
   async setCodepage(value: string) {
@@ -113,5 +81,21 @@ export default class Printer {
 
   async close() {
     return this.model.profile.finalize();
+  }
+
+  static async connect(
+    _model: SupportedModel | Model,
+    connection: Connection,
+  ): Promise<Printer> {
+    let model: Model
+    if(typeof _model === 'string') {
+      model = new Model(_model)
+    } else {
+      model = _model
+    }
+    await connection.open();
+    model.profile.connection = connection;
+    await model.profile.initialize?.();
+    return new Printer(model);
   }
 }

--- a/src/Printer.ts
+++ b/src/Printer.ts
@@ -71,19 +71,19 @@ export default class Printer {
     return this.model.profile.drawer(number, on_time, off_time);
   }
 
-  async draw(image: Image) {
+  async draw(image: Image): Promise<void> {
     return this.model.profile.draw(image);
   }
 
-  async qrcode(data: string, size: number = null) {
+  async qrcode(data: string, size: number = null): Promise<void> {
     return this.model.profile.qrcode(data, size);
   }
 
-  set alignment(align: Align) {
-    this.model.profile.alignment = align;
+  async setAlignment(align: Align): Promise<void> {
+    return this.model.profile.setAlignment(align);
   }
 
-  async write(text: string, styles: number = 0) {
+  async write(text: string, styles: number = 0): Promise<void> {
     return this.model.profile.write(text, styles);
   }
 

--- a/src/Printer.ts
+++ b/src/Printer.ts
@@ -31,7 +31,7 @@ export enum Drawer {
 export default class Printer {
   private model: Model;
 
-  static async connectPrinter(
+  static async connect(
     model: Model,
     connection: Connection,
   ): Promise<Printer> {

--- a/src/Printer.ts
+++ b/src/Printer.ts
@@ -83,7 +83,7 @@ export default class Printer {
     return this.model.profile.finalize();
   }
 
-  static async connect(
+  static async CONNECT(
     _model: SupportedModel | Model,
     connection: Connection,
   ): Promise<Printer> {

--- a/src/Style.ts
+++ b/src/Style.ts
@@ -4,6 +4,5 @@ export enum Style {
   Underline = 4,
   Condensed = 8,
   DoubleWidth = 16,
-  DoubleHeight = 32
+  DoubleHeight = 32,
 }
-

--- a/src/Style.ts
+++ b/src/Style.ts
@@ -1,0 +1,9 @@
+export enum Style {
+  Bold = 1,
+  Italic = 2,
+  Underline = 4,
+  Condensed = 8,
+  DoubleWidth = 16,
+  DoubleHeight = 32
+}
+

--- a/src/capabilities.ts
+++ b/src/capabilities.ts
@@ -454,7 +454,7 @@ export type CodePage = {
   command: string;
 };
 
-type Models = (typeof capabilities)['models'];
+type Models = typeof capabilities['models'];
 export type Profile = Models[number]['profile'];
 export type SupportedModel = Models[number]['model'];
 

--- a/src/capabilities.ts
+++ b/src/capabilities.ts
@@ -1,80 +1,4 @@
-export type Font = {
-  /**
-   * Font name, ex: Font A, Font B
-   */
-  name: string;
-
-  /**
-   * Max columns to use in this font
-   */
-  columns: number;
-};
-
-export type CodePage = {
-  /**
-   * Code page, ex: cp850, utf8
-   */
-  code: string;
-
-  /**
-   * Command to use this code page
-   */
-  command: string;
-};
-
-export type Capability = {
-  /**
-   * Profile to process printer commands
-   */
-  profile: string;
-
-  /**
-   * Printer brand
-   */
-  brand: string;
-
-  /**
-   * Printer model reference
-   */
-  model: string;
-
-  /**
-   * Printer model name
-   */
-  name?: string;
-
-  /**
-   * Default columns number
-   */
-  columns: number;
-
-  /**
-   * Default feed rows to cut properly
-   */
-  feed?: number;
-
-  /**
-   * Available fonts
-   */
-  fonts: Font[];
-
-  /**
-   * Default code page
-   */
-  codepage: string;
-
-  /**
-   * Initialize printer with this command
-   */
-  initialize?: string;
-
-  /**
-   * Available code pages
-   */
-  codepages: CodePage[];
-};
-
-export default {
+const capabilities = {
   models: [
     // Bematech
     {
@@ -504,4 +428,86 @@ export default {
       },
     },
   },
+} as const;
+
+export type Font = {
+  /**
+   * Font name, ex: Font A, Font B
+   */
+  name: string;
+
+  /**
+   * Max columns to use in this font
+   */
+  columns: number;
 };
+
+export type CodePage = {
+  /**
+   * Code page, ex: cp850, utf8
+   */
+  code: string;
+
+  /**
+   * Command to use this code page
+   */
+  command: string;
+};
+
+type Models = (typeof capabilities)['models'];
+export type Profile = Models[number]['profile'];
+export type SupportedModel = Models[number]['model'];
+
+export type Capability = {
+  /**
+   * Profile to process printer commands
+   */
+  profile: string;
+
+  /**
+   * Printer brand
+   */
+  brand: string;
+
+  /**
+   * Printer model reference
+   */
+  model: string;
+
+  /**
+   * Printer model name
+   */
+  name?: string;
+
+  /**
+   * Default columns number
+   */
+  columns: number;
+
+  /**
+   * Default feed rows to cut properly
+   */
+  feed?: number;
+
+  /**
+   * Available fonts
+   */
+  fonts: Font[];
+
+  /**
+   * Default code page
+   */
+  codepage: string;
+
+  /**
+   * Initialize printer with this command
+   */
+  initialize?: string;
+
+  /**
+   * Available code pages
+   */
+  codepages: CodePage[];
+};
+
+export default capabilities;

--- a/src/connection/InMemory.ts
+++ b/src/connection/InMemory.ts
@@ -3,15 +3,15 @@ import { Connection } from '.';
 export default class InMemory implements Connection {
   list: Buffer[];
 
-  open(): void {
+  async open(): Promise<void> {
     this.list = [];
   }
 
-  write(data: Buffer): void {
+  async write(data: Buffer): Promise<void> {
     this.list.push(data);
   }
 
-  close(): void {}
+  async close(): Promise<void> {}
 
   buffer() {
     return Buffer.concat(this.list);

--- a/src/connection/WebUSB.ts
+++ b/src/connection/WebUSB.ts
@@ -1,6 +1,6 @@
 import { Connection } from '.';
 
-export default class WebUSB implements Connection<USBOutTransferResult> {
+export default class WebUSB implements Connection {
   private endpointNumber: number = 1;
 
   constructor(private device: USBDevice) {}
@@ -22,8 +22,8 @@ export default class WebUSB implements Connection<USBOutTransferResult> {
     this.endpointNumber = endpoint.endpointNumber;
   }
 
-  write(data: Buffer): Promise<USBOutTransferResult> {
-    return this.device.transferOut(this.endpointNumber, data);
+  async write(data: Buffer): Promise<void> {
+    await this.device.transferOut(this.endpointNumber, data);
   }
 
   close(): Promise<void> {

--- a/src/connection/WebUSB.ts
+++ b/src/connection/WebUSB.ts
@@ -1,6 +1,6 @@
 import { Connection } from '.';
 
-export default class WebUSB implements Connection {
+export default class WebUSB implements Connection<USBOutTransferResult> {
   private endpointNumber: number = 1;
 
   constructor(private device: USBDevice) {}

--- a/src/connection/index.ts
+++ b/src/connection/index.ts
@@ -1,8 +1,8 @@
 export { default as InMemory } from './InMemory';
 export { default as WebUSB } from './WebUSB';
 
-export interface Connection {
-  open(): void;
-  write(data: Buffer): void;
-  close(): void;
+export interface Connection<WriteResult = void> {
+  open(): Promise<void>;
+  write(data: Buffer): Promise<WriteResult>;
+  close(): Promise<void>;
 }

--- a/src/connection/index.ts
+++ b/src/connection/index.ts
@@ -1,8 +1,8 @@
 export { default as InMemory } from './InMemory';
 export { default as WebUSB } from './WebUSB';
 
-export interface Connection<WriteResult = void> {
+export interface Connection {
   open(): Promise<void>;
-  write(data: Buffer): Promise<WriteResult>;
+  write(data: Buffer): Promise<void>;
   close(): Promise<void>;
 }

--- a/src/profile/Bematech.ts
+++ b/src/profile/Bematech.ts
@@ -1,5 +1,6 @@
 import Epson from './Epson';
-import { Drawer, Style } from '../Printer';
+import {Style} from "../Style";
+import {Drawer} from "../Drawer";
 import { Font } from '../capabilities';
 
 export default class Bematech extends Epson {

--- a/src/profile/Bematech.ts
+++ b/src/profile/Bematech.ts
@@ -1,6 +1,6 @@
 import Epson from './Epson';
-import {Style} from "../Style";
-import {Drawer} from "../Drawer";
+import { Style } from '../Style';
+import { Drawer } from '../Drawer';
 import { Font } from '../capabilities';
 
 export default class Bematech extends Epson {

--- a/src/profile/Bematech.ts
+++ b/src/profile/Bematech.ts
@@ -3,39 +3,41 @@ import { Drawer, Style } from '../Printer';
 import { Font } from '../capabilities';
 
 export default class Bematech extends Epson {
-  protected setStyle(style: Style, enable: boolean): void {
+  protected async setStyle(style: Style, enable: boolean): Promise<void> {
     if (this.font.name != 'Font C') {
       return super.setStyle(style, enable);
     }
     if (enable) {
       // enable styles
       if (Style.Bold == style) {
-        this.connection.write(Buffer.from('\x1BE', 'ascii'));
-        return;
+        return this.connection.write(Buffer.from('\x1BE', 'ascii'));
       }
     } else {
       // disable styles
       if (Style.Bold == style) {
-        this.connection.write(Buffer.from('\x1BF', 'ascii'));
-        return;
+        return this.connection.write(Buffer.from('\x1BF', 'ascii'));
       }
     }
     return super.setStyle(style, enable);
   }
 
-  buzzer(): void {
+  async buzzer(): Promise<void> {
     if (this.capabilities.model == 'MP-2800 TH') {
-      this.connection.write(Buffer.from('\x1BB\x02\x01', 'ascii'));
+      return this.connection.write(Buffer.from('\x1BB\x02\x01', 'ascii'));
     } else if (this.font.name != 'Font C') {
-      this.connection.write(
+      return this.connection.write(
         Buffer.from('\x1B(A\x05\x00ad\x02\x02\x01', 'ascii'),
       );
     } else {
-      super.buzzer();
+      return super.buzzer();
     }
   }
 
-  drawer(number: Drawer, on_time: number, off_time: number): void {
+  async drawer(
+    number: Drawer,
+    on_time: number,
+    off_time: number,
+  ): Promise<void> {
     if (this.font.name != 'Font C') {
       return super.drawer(number, on_time, off_time);
     }
@@ -46,7 +48,7 @@ export default class Bematech extends Epson {
     const on_time_char = String.fromCharCode(
       Math.max(Math.min(on_time, 255), 50),
     );
-    this.connection.write(
+    return this.connection.write(
       Buffer.from('\x1B' + index[number] + on_time_char, 'ascii'),
     );
   }
@@ -59,22 +61,21 @@ export default class Bematech extends Epson {
     const _size = String.fromCharCode(Math.min(11, Math.max(1, size || 4)) * 2);
     const version = String.fromCharCode(0);
     const encoding = String.fromCharCode(1);
-    this.connection.write(Buffer.from('\x1DkQ', 'ascii'));
-    this.connection.write(
+    await this.connection.write(Buffer.from('\x1DkQ', 'ascii'));
+    await this.connection.write(
       Buffer.from(error + _size + version + encoding, 'ascii'),
     );
-    this.connection.write(Buffer.from(pL + pH, 'ascii'));
-    this.connection.write(Buffer.from(data, 'ascii'));
-    this.connection.write(Buffer.from('\x00', 'ascii'));
-    this.feed(1);
+    await this.connection.write(Buffer.from(pL + pH, 'ascii'));
+    await this.connection.write(Buffer.from(data, 'ascii'));
+    await this.connection.write(Buffer.from('\x00', 'ascii'));
+    return this.feed(1);
   }
 
-  protected fontChanged(current: Font, previows: Font) {
+  protected async fontChanged(current: Font, previows: Font): Promise<void> {
     if (current.name == 'Font C') {
-      this.connection.write(Buffer.from('\x1D\xf950', 'ascii'));
-      return;
+      return this.connection.write(Buffer.from('\x1D\xf950', 'ascii'));
     }
-    this.connection.write(Buffer.from('\x1D\xf951', 'ascii'));
-    super.fontChanged(current, previows);
+    await this.connection.write(Buffer.from('\x1D\xf951', 'ascii'));
+    return super.fontChanged(current, previows);
   }
 }

--- a/src/profile/ControliD.ts
+++ b/src/profile/ControliD.ts
@@ -3,18 +3,16 @@ import { Style } from '../Printer';
 import { Font } from '../capabilities';
 
 export default class ControliD extends Epson {
-  protected setStyle(style: Style, enable: boolean): void {
+  protected async setStyle(style: Style, enable: boolean): Promise<void> {
     if (enable) {
       // enable styles
       if (Style.Bold == style) {
-        this.connection.write(Buffer.from('\x1BE\x01', 'ascii'));
-        return;
+        return this.connection.write(Buffer.from('\x1BE\x01', 'ascii'));
       }
     } else {
       // disable styles
       if (Style.Bold == style) {
-        this.connection.write(Buffer.from('\x1BE\x00', 'ascii'));
-        return;
+        return this.connection.write(Buffer.from('\x1BE\x00', 'ascii'));
       }
     }
     return super.setStyle(style, enable);
@@ -23,23 +21,23 @@ export default class ControliD extends Epson {
   async qrcode(data: string, size: number) {
     // Print iD Touch qrcode works with epson commands
     if (this.capabilities.model == 'PrintiD-Touch') {
-      await super.qrcode(data, size);
+      return super.qrcode(data, size);
     } else {
-      await this.drawQrcode(data, size);
+      return this.drawQrcode(data, size);
     }
   }
 
-  initialize() {
-    super.initialize();
-    this.fontChanged(this.font, this.font);
+  async initialize() {
+    await super.initialize();
+    return this.fontChanged(this.font, this.font);
   }
 
-  protected fontChanged(current: Font, previows: Font) {
+  protected async fontChanged(current: Font, previows: Font) {
     if (current.name == 'Font C') {
-      this.connection.write(Buffer.from('\x1BM\x02', 'ascii'));
+      return this.connection.write(Buffer.from('\x1BM\x02', 'ascii'));
     } else {
       // Font A and B
-      super.fontChanged(current, previows);
+      return super.fontChanged(current, previows);
     }
   }
 }

--- a/src/profile/ControliD.ts
+++ b/src/profile/ControliD.ts
@@ -1,5 +1,5 @@
 import Epson from './Epson';
-import { Style } from '../Printer';
+import {Style} from "../Style";
 import { Font } from '../capabilities';
 
 export default class ControliD extends Epson {

--- a/src/profile/ControliD.ts
+++ b/src/profile/ControliD.ts
@@ -1,5 +1,5 @@
 import Epson from './Epson';
-import {Style} from "../Style";
+import { Style } from '../Style';
 import { Font } from '../capabilities';
 
 export default class ControliD extends Epson {

--- a/src/profile/Daruma.ts
+++ b/src/profile/Daruma.ts
@@ -11,13 +11,13 @@ export default class Daruma extends Epson {
     return this.connection.write(Buffer.from('\x1B' + index[number], 'ascii'));
   }
 
-  set alignment(align: Align) {
+  async setAlignment(align: Align): Promise<void> {
     const cmd = {
       [Align.Left]: '\x1Bj0',
       [Align.Center]: '\x1Bj1',
       [Align.Right]: '\x1Bj2',
     };
-    this.connection.write(Buffer.from(cmd[align], 'ascii'));
+    return this.connection.write(Buffer.from(cmd[align], 'ascii'));
   }
 
   protected async setStyle(style: Style, enable: boolean): Promise<void> {

--- a/src/profile/Daruma.ts
+++ b/src/profile/Daruma.ts
@@ -38,17 +38,17 @@ export default class Daruma extends Epson {
   protected async setMode(mode: number, enable: boolean): Promise<void> {
     if (enable) {
       if (mode & Style.DoubleWidth) {
-        return this.connection.write(Buffer.from('\x0E', 'ascii'));
+        await this.connection.write(Buffer.from('\x0E', 'ascii'));
       }
       if (mode & Style.DoubleHeight) {
-        return this.connection.write(Buffer.from('\x1Bw1', 'ascii'));
+        await this.connection.write(Buffer.from('\x1Bw1', 'ascii'));
       }
     } else {
       if (mode & Style.DoubleHeight) {
-        return this.connection.write(Buffer.from('\x1Bw0', 'ascii'));
+        await this.connection.write(Buffer.from('\x1Bw0', 'ascii'));
       }
       if (mode & Style.DoubleWidth) {
-        return this.connection.write(Buffer.from('\x14', 'ascii'));
+        await this.connection.write(Buffer.from('\x14', 'ascii'));
       }
     }
   }

--- a/src/profile/Daruma.ts
+++ b/src/profile/Daruma.ts
@@ -55,8 +55,8 @@ export default class Daruma extends Epson {
     }
   }
 
-  feed(lines: number): void {
-    this.connection.write(Buffer.from('\r\n'.repeat(lines), 'ascii'));
+  async feed(lines: number): Promise<void> {
+    return this.connection.write(Buffer.from('\r\n'.repeat(lines), 'ascii'));
   }
 
   initialize() {

--- a/src/profile/Daruma.ts
+++ b/src/profile/Daruma.ts
@@ -3,12 +3,12 @@ import { Drawer, Style, Align } from '../Printer';
 import { Font } from '../capabilities';
 
 export default class Daruma extends Epson {
-  drawer(number: Drawer, _: number, __: number): void {
+  async drawer(number: Drawer, _: number, __: number): Promise<void> {
     const index = {
       [Drawer.First]: 'p',
       [Drawer.Second]: 'p',
     };
-    this.connection.write(Buffer.from('\x1B' + index[number], 'ascii'));
+    return this.connection.write(Buffer.from('\x1B' + index[number], 'ascii'));
   }
 
   set alignment(align: Align) {
@@ -20,37 +20,35 @@ export default class Daruma extends Epson {
     this.connection.write(Buffer.from(cmd[align], 'ascii'));
   }
 
-  protected setStyle(style: Style, enable: boolean): void {
+  protected async setStyle(style: Style, enable: boolean): Promise<void> {
     if (enable) {
       // enable styles
       if (Style.Bold == style) {
-        this.connection.write(Buffer.from('\x1BE', 'ascii'));
-        return;
+        return this.connection.write(Buffer.from('\x1BE', 'ascii'));
       }
     } else {
       // disable styles
       if (Style.Bold == style) {
-        this.connection.write(Buffer.from('\x1BF', 'ascii'));
-        return;
+        return this.connection.write(Buffer.from('\x1BF', 'ascii'));
       }
     }
     return super.setStyle(style, enable);
   }
 
-  protected setMode(mode: number, enable: boolean): void {
+  protected async setMode(mode: number, enable: boolean): Promise<void> {
     if (enable) {
       if (mode & Style.DoubleWidth) {
-        this.connection.write(Buffer.from('\x0E', 'ascii'));
+        return this.connection.write(Buffer.from('\x0E', 'ascii'));
       }
       if (mode & Style.DoubleHeight) {
-        this.connection.write(Buffer.from('\x1Bw1', 'ascii'));
+        return this.connection.write(Buffer.from('\x1Bw1', 'ascii'));
       }
     } else {
       if (mode & Style.DoubleHeight) {
-        this.connection.write(Buffer.from('\x1Bw0', 'ascii'));
+        return this.connection.write(Buffer.from('\x1Bw0', 'ascii'));
       }
       if (mode & Style.DoubleWidth) {
-        this.connection.write(Buffer.from('\x14', 'ascii'));
+        return this.connection.write(Buffer.from('\x14', 'ascii'));
       }
     }
   }
@@ -59,13 +57,13 @@ export default class Daruma extends Epson {
     return this.connection.write(Buffer.from('\r\n'.repeat(lines), 'ascii'));
   }
 
-  initialize() {
-    this.fontChanged(this.font, this.font);
+  async initialize() {
+    return this.fontChanged(this.font, this.font);
   }
 
-  protected fontChanged(current: Font, previows: Font) {
-    super.fontChanged(current, previows);
-    this.applyCodePage();
+  protected async fontChanged(current: Font, previows: Font) {
+    await super.fontChanged(current, previows);
+    return this.applyCodePage();
   }
 
   async qrcode(data: string, size: number) {
@@ -74,10 +72,10 @@ export default class Daruma extends Epson {
     const pH = String.fromCharCode((len >> 8) & 0xff);
     const error = 'M';
     const _size = String.fromCharCode(Math.min(7, Math.max(3, size || 4)));
-    this.connection.write(Buffer.from('\x1B\x81', 'ascii'));
-    this.connection.write(Buffer.from(pL + pH, 'ascii'));
-    this.connection.write(Buffer.from(_size + error, 'ascii'));
-    this.connection.write(Buffer.from(data, 'ascii'));
+    await this.connection.write(Buffer.from('\x1B\x81', 'ascii'));
+    await this.connection.write(Buffer.from(pL + pH, 'ascii'));
+    await this.connection.write(Buffer.from(_size + error, 'ascii'));
+    return this.connection.write(Buffer.from(data, 'ascii'));
   }
 
   protected get bitmapCmd(): string {

--- a/src/profile/Daruma.ts
+++ b/src/profile/Daruma.ts
@@ -1,7 +1,7 @@
 import Epson from './Epson';
-import {Align} from "../Align";
-import {Style} from "../Style";
-import {Drawer} from "../Drawer";
+import { Align } from '../Align';
+import { Style } from '../Style';
+import { Drawer } from '../Drawer';
 import { Font } from '../capabilities';
 
 export default class Daruma extends Epson {
@@ -60,6 +60,13 @@ export default class Daruma extends Epson {
   }
 
   async initialize() {
+    await this.setCodepage(this.capabilities.codepage);
+    await this.setColumns(this.capabilities.columns);
+    if (this.capabilities.initialize) {
+      await this.connection.write(
+        Buffer.from(this.capabilities.initialize, 'ascii'),
+      );
+    }
     return this.fontChanged(this.font, this.font);
   }
 

--- a/src/profile/Daruma.ts
+++ b/src/profile/Daruma.ts
@@ -1,5 +1,7 @@
 import Epson from './Epson';
-import { Drawer, Style, Align } from '../Printer';
+import {Align} from "../Align";
+import {Style} from "../Style";
+import {Drawer} from "../Drawer";
 import { Font } from '../capabilities';
 
 export default class Daruma extends Epson {

--- a/src/profile/Dataregis.ts
+++ b/src/profile/Dataregis.ts
@@ -1,7 +1,7 @@
 import Elgin from './Elgin';
 
 export default class Dataregis extends Elgin {
-  buzzer(): void {
-    this.connection.write(Buffer.from('\x07', 'ascii'));
+  async buzzer(): Promise<void> {
+    return this.connection.write(Buffer.from('\x07', 'ascii'));
   }
 }

--- a/src/profile/Diebold.ts
+++ b/src/profile/Diebold.ts
@@ -1,5 +1,5 @@
 import Elgin from './Elgin';
-import {Drawer} from "../Drawer";
+import { Drawer } from '../Drawer';
 
 export default class Diebold extends Elgin {
   async buzzer(): Promise<void> {

--- a/src/profile/Diebold.ts
+++ b/src/profile/Diebold.ts
@@ -1,5 +1,5 @@
 import Elgin from './Elgin';
-import { Drawer } from '../Printer';
+import {Drawer} from "../Drawer";
 
 export default class Diebold extends Elgin {
   async buzzer(): Promise<void> {

--- a/src/profile/Diebold.ts
+++ b/src/profile/Diebold.ts
@@ -2,11 +2,15 @@ import Elgin from './Elgin';
 import { Drawer } from '../Printer';
 
 export default class Diebold extends Elgin {
-  buzzer(): void {
-    this.connection.write(Buffer.from('\x07', 'ascii'));
+  async buzzer(): Promise<void> {
+    return this.connection.write(Buffer.from('\x07', 'ascii'));
   }
 
-  drawer(number: Drawer, on_time: number, off_time: number): void {
+  async drawer(
+    number: Drawer,
+    on_time: number,
+    off_time: number,
+  ): Promise<void> {
     const index = {
       [Drawer.First]: '0',
       [Drawer.Second]: '1',
@@ -17,7 +21,7 @@ export default class Diebold extends Elgin {
     const off_time_char = String.fromCharCode(
       Math.min(Math.trunc(off_time / 2), 65),
     );
-    this.connection.write(
+    return this.connection.write(
       Buffer.from(
         '\x1B&' + index[number] + on_time_char + off_time_char,
         'ascii',

--- a/src/profile/Elgin.ts
+++ b/src/profile/Elgin.ts
@@ -1,7 +1,7 @@
 import Epson from './Epson';
-import {Style} from "../Style";
-import {Cut} from "../Cut";
-import {Drawer} from "../Drawer";
+import { Style } from '../Style';
+import { Cut } from '../Cut';
+import { Drawer } from '../Drawer';
 
 export default class Elgin extends Epson {
   async cutter(mode: Cut): Promise<void> {

--- a/src/profile/Elgin.ts
+++ b/src/profile/Elgin.ts
@@ -2,14 +2,14 @@ import Epson from './Epson';
 import { Drawer, Style, Cut } from '../Printer';
 
 export default class Elgin extends Epson {
-  cutter(mode: Cut): void {
+  async cutter(mode: Cut): Promise<void> {
     if (this.capabilities.model == 'I9') {
       return this.connection.write(Buffer.from('\x1DV0', 'ascii'));
     }
     super.cutter(mode);
   }
 
-  buzzer(): void {
+  async buzzer(): Promise<void> {
     this.connection.write(Buffer.from('\x1B(A\x05\x00ad\x02\x02\x01', 'ascii'));
   }
 

--- a/src/profile/Elgin.ts
+++ b/src/profile/Elgin.ts
@@ -57,17 +57,17 @@ export default class Elgin extends Epson {
     }
     if (enable) {
       if (mode & Style.DoubleWidth) {
-        return this.connection.write(Buffer.from('\x1BW\x01', 'ascii'));
+        await this.connection.write(Buffer.from('\x1BW\x01', 'ascii'));
       }
       if (mode & Style.DoubleHeight) {
-        return this.connection.write(Buffer.from('\x1Bd\x01', 'ascii'));
+        await this.connection.write(Buffer.from('\x1Bd\x01', 'ascii'));
       }
     } else {
       if (mode & Style.DoubleHeight) {
-        return this.connection.write(Buffer.from('\x1Bd\x00', 'ascii'));
+        await this.connection.write(Buffer.from('\x1Bd\x00', 'ascii'));
       }
       if (mode & Style.DoubleWidth) {
-        return this.connection.write(Buffer.from('\x1BW\x00', 'ascii'));
+        await this.connection.write(Buffer.from('\x1BW\x00', 'ascii'));
       }
     }
   }

--- a/src/profile/Elgin.ts
+++ b/src/profile/Elgin.ts
@@ -6,14 +6,18 @@ export default class Elgin extends Epson {
     if (this.capabilities.model == 'I9') {
       return this.connection.write(Buffer.from('\x1DV0', 'ascii'));
     }
-    super.cutter(mode);
+    return super.cutter(mode);
   }
 
   async buzzer(): Promise<void> {
     this.connection.write(Buffer.from('\x1B(A\x05\x00ad\x02\x02\x01', 'ascii'));
   }
 
-  drawer(number: Drawer, on_time: number, off_time: number): void {
+  async drawer(
+    number: Drawer,
+    on_time: number,
+    off_time: number,
+  ): Promise<void> {
     if (this.capabilities.model.startsWith('I')) {
       return super.drawer(number, on_time, off_time);
     }
@@ -24,48 +28,46 @@ export default class Elgin extends Epson {
     const on_time_char = String.fromCharCode(
       Math.max(Math.min(on_time, 200), 50),
     );
-    this.connection.write(
+    return this.connection.write(
       Buffer.from('\x1B' + index[number] + on_time_char, 'ascii'),
     );
   }
 
-  protected setStyle(style: Style, enable: boolean): void {
+  protected async setStyle(style: Style, enable: boolean): Promise<void> {
     if (this.capabilities.model == 'I9') {
       return super.setStyle(style, enable);
     }
     if (enable) {
       // enable styles
       if (Style.Bold == style) {
-        this.connection.write(Buffer.from('\x1BE', 'ascii'));
-        return;
+        return this.connection.write(Buffer.from('\x1BE', 'ascii'));
       }
     } else {
       // disable styles
       if (Style.Bold == style) {
-        this.connection.write(Buffer.from('\x1BF', 'ascii'));
-        return;
+        return this.connection.write(Buffer.from('\x1BF', 'ascii'));
       }
     }
     return super.setStyle(style, enable);
   }
 
-  protected setMode(mode: number, enable: boolean): void {
+  protected async setMode(mode: number, enable: boolean): Promise<void> {
     if (this.capabilities.model == 'I9') {
       return super.setMode(mode, enable);
     }
     if (enable) {
       if (mode & Style.DoubleWidth) {
-        this.connection.write(Buffer.from('\x1BW\x01', 'ascii'));
+        return this.connection.write(Buffer.from('\x1BW\x01', 'ascii'));
       }
       if (mode & Style.DoubleHeight) {
-        this.connection.write(Buffer.from('\x1Bd\x01', 'ascii'));
+        return this.connection.write(Buffer.from('\x1Bd\x01', 'ascii'));
       }
     } else {
       if (mode & Style.DoubleHeight) {
-        this.connection.write(Buffer.from('\x1Bd\x00', 'ascii'));
+        return this.connection.write(Buffer.from('\x1Bd\x00', 'ascii'));
       }
       if (mode & Style.DoubleWidth) {
-        this.connection.write(Buffer.from('\x1BW\x00', 'ascii'));
+        return this.connection.write(Buffer.from('\x1BW\x00', 'ascii'));
       }
     }
   }
@@ -77,11 +79,13 @@ export default class Elgin extends Epson {
     const type = String.fromCharCode(2);
     const error = 'M';
     const _size = String.fromCharCode(Math.min(255, Math.max(1, size || 4)));
-    this.connection.write(
+    await this.connection.write(
       Buffer.from('\x1Do\x00' + _size + '\x00' + type, 'ascii'),
     );
-    this.connection.write(Buffer.from('\x1Dk\x0B' + error + 'A,', 'ascii'));
-    this.connection.write(Buffer.from(data, 'ascii'));
-    this.connection.write(Buffer.from('\x00', 'ascii'));
+    await this.connection.write(
+      Buffer.from('\x1Dk\x0B' + error + 'A,', 'ascii'),
+    );
+    await this.connection.write(Buffer.from(data, 'ascii'));
+    return this.connection.write(Buffer.from('\x00', 'ascii'));
   }
 }

--- a/src/profile/Elgin.ts
+++ b/src/profile/Elgin.ts
@@ -1,5 +1,7 @@
 import Epson from './Epson';
-import { Drawer, Style, Cut } from '../Printer';
+import {Style} from "../Style";
+import {Cut} from "../Cut";
+import {Drawer} from "../Drawer";
 
 export default class Elgin extends Epson {
   async cutter(mode: Cut): Promise<void> {

--- a/src/profile/Epson.ts
+++ b/src/profile/Epson.ts
@@ -3,7 +3,7 @@ import { Profile } from '.';
 import { Font } from '../capabilities';
 
 export default class Epson extends Profile {
-  feed(lines: number): void {
+  async feed(lines: number): Promise<void> {
     if (lines > 1) {
       const count = Math.trunc(lines / 255);
       let cmd = ('\x1Bd' + String.fromCharCode(Math.min(lines, 255))).repeat(
@@ -13,18 +13,18 @@ export default class Epson extends Profile {
       if (remaining > 0) {
         cmd += '\x1Bd' + String.fromCharCode(remaining);
       }
-      this.connection.write(Buffer.from(cmd));
+      return this.connection.write(Buffer.from(cmd));
     } else {
-      this.connection.write(Buffer.from('\r\n', 'ascii'));
+      return this.connection.write(Buffer.from('\r\n', 'ascii'));
     }
   }
 
-  cutter(_: Cut): void {
-    this.connection.write(Buffer.from('\x1Bm', 'ascii'));
+  async cutter(_: Cut): Promise<void> {
+    return this.connection.write(Buffer.from('\x1Bm', 'ascii'));
   }
 
-  buzzer(): void {
-    this.connection.write(Buffer.from('\x07', 'ascii'));
+  async buzzer(): Promise<void> {
+    return this.connection.write(Buffer.from('\x07', 'ascii'));
   }
 
   drawer(number: Drawer, on_time: number, off_time: number): void {

--- a/src/profile/Epson.ts
+++ b/src/profile/Epson.ts
@@ -1,4 +1,7 @@
-import { Align, Style, Drawer, Cut } from '../Printer';
+import {Align} from "../Align";
+import {Style} from "../Style";
+import {Cut} from "../Cut";
+import {Drawer} from "../Drawer";
 import { Profile } from '.';
 import { Font } from '../capabilities';
 

--- a/src/profile/Epson.ts
+++ b/src/profile/Epson.ts
@@ -48,14 +48,13 @@ export default class Epson extends Profile {
     );
   }
 
-  // TODO: Cannot use setter syntax when calling async funcitons and allow the consumer to await it.
-  set alignment(align: Align) {
+  async setAlignment(align: Align) {
     const cmd = {
       [Align.Left]: '\x1Ba0',
       [Align.Center]: '\x1Ba1',
       [Align.Right]: '\x1Ba2',
     };
-    this.connection.write(Buffer.from(cmd[align], 'ascii'));
+    return this.connection.write(Buffer.from(cmd[align], 'ascii'));
   }
 
   protected async setMode(mode: number, enable: boolean): Promise<void> {

--- a/src/profile/Epson.ts
+++ b/src/profile/Epson.ts
@@ -27,7 +27,11 @@ export default class Epson extends Profile {
     return this.connection.write(Buffer.from('\x07', 'ascii'));
   }
 
-  drawer(number: Drawer, on_time: number, off_time: number): void {
+  async drawer(
+    number: Drawer,
+    on_time: number,
+    off_time: number,
+  ): Promise<void> {
     const index = {
       [Drawer.First]: 0,
       [Drawer.Second]: 1,
@@ -39,11 +43,12 @@ export default class Epson extends Profile {
       Math.min(Math.trunc(off_time / 2), 255),
     );
     const index_char = String.fromCharCode(index[number]);
-    this.connection.write(
+    return this.connection.write(
       Buffer.from('\x1Bp' + index_char + on_time_char + off_time_char, 'ascii'),
     );
   }
 
+  // TODO: Cannot use setter syntax when calling async funcitons and allow the consumer to await it.
   set alignment(align: Align) {
     const cmd = {
       [Align.Left]: '\x1Ba0',
@@ -53,7 +58,7 @@ export default class Epson extends Profile {
     this.connection.write(Buffer.from(cmd[align], 'ascii'));
   }
 
-  protected setMode(mode: number, enable: boolean): void {
+  protected async setMode(mode: number, enable: boolean): Promise<void> {
     let byte = 0b00000000; // keep Font A selected
     if (this.font.name == 'Font B') {
       byte |= 0b00000001; // keep Font B selected
@@ -70,39 +75,39 @@ export default class Epson extends Profile {
       mask = 0b00110001;
     }
     if (before != byte) {
-      this.connection.write(
+      return this.connection.write(
         Buffer.from('\x1B!' + String.fromCharCode(byte & mask), 'ascii'),
       );
     }
   }
 
-  protected setStyle(style: Style, enable: boolean): void {
+  protected async setStyle(style: Style, enable: boolean): Promise<void> {
     if (enable) {
       // enable styles
       if (Style.Condensed == style) {
-        this.connection.write(Buffer.from('\x1B\x0f', 'ascii'));
+        return this.connection.write(Buffer.from('\x1B\x0f', 'ascii'));
       } else if (Style.Bold == style) {
-        this.connection.write(Buffer.from('\x1BE1', 'ascii'));
+        return this.connection.write(Buffer.from('\x1BE1', 'ascii'));
       } else if (Style.Italic == style) {
-        this.connection.write(Buffer.from('\x1B4', 'ascii'));
+        return this.connection.write(Buffer.from('\x1B4', 'ascii'));
       } else if (Style.Underline == style) {
-        this.connection.write(Buffer.from('\x1B-1', 'ascii'));
+        return this.connection.write(Buffer.from('\x1B-1', 'ascii'));
       }
     } else {
       // disable styles
       if (Style.Underline == style) {
-        this.connection.write(Buffer.from('\x1B-0', 'ascii'));
+        return this.connection.write(Buffer.from('\x1B-0', 'ascii'));
       } else if (Style.Italic == style) {
-        this.connection.write(Buffer.from('\x1B5', 'ascii'));
+        return this.connection.write(Buffer.from('\x1B5', 'ascii'));
       } else if (Style.Bold == style) {
-        this.connection.write(Buffer.from('\x1BE0', 'ascii'));
+        return this.connection.write(Buffer.from('\x1BE0', 'ascii'));
       } else if (Style.Condensed == style) {
-        this.connection.write(Buffer.from('\x12', 'ascii'));
+        return this.connection.write(Buffer.from('\x12', 'ascii'));
       }
     }
   }
 
-  protected setCharSize({
+  protected async setCharSize({
     width = 1,
     height = 1,
   }: {
@@ -113,7 +118,7 @@ export default class Epson extends Profile {
     height = Math.max(1, Math.min(height, 8));
     const n = (height - 1) | ((width - 1) << 4);
 
-    this.connection.write(
+    return this.connection.write(
       Buffer.from(`\x1D!${String.fromCharCode(n)}`, 'ascii'),
     );
   }
@@ -125,23 +130,29 @@ export default class Epson extends Profile {
     const len = data.length + 3;
     const pL = String.fromCharCode(len & 0xff);
     const pH = String.fromCharCode((len >> 8) & 0xff);
-    this.connection.write(
+    await this.connection.write(
       Buffer.from('\x1D(k\x04\x001A' + tipo + '\x00', 'ascii'),
     );
-    this.connection.write(Buffer.from('\x1D(k\x03\x001C' + _size, 'ascii'));
-    this.connection.write(Buffer.from('\x1D(k\x03\x001E' + error, 'ascii'));
-    this.connection.write(Buffer.from('\x1D(k' + pL + pH + '1P0', 'ascii'));
-    this.connection.write(Buffer.from(data, 'ascii'));
-    this.connection.write(Buffer.from('\x1D(k\x03\x001Q0', 'ascii'));
+    await this.connection.write(
+      Buffer.from('\x1D(k\x03\x001C' + _size, 'ascii'),
+    );
+    await this.connection.write(
+      Buffer.from('\x1D(k\x03\x001E' + error, 'ascii'),
+    );
+    await this.connection.write(
+      Buffer.from('\x1D(k' + pL + pH + '1P0', 'ascii'),
+    );
+    await this.connection.write(Buffer.from(data, 'ascii'));
+    return this.connection.write(Buffer.from('\x1D(k\x03\x001Q0', 'ascii'));
   }
 
-  protected fontChanged(current: Font, previows: Font) {
+  protected async fontChanged(current: Font, previows: Font) {
     if (current.name == 'Font A') {
-      this.connection.write(Buffer.from('\x1BM\x00', 'ascii'));
+      await this.connection.write(Buffer.from('\x1BM\x00', 'ascii'));
     } else {
       // Font B
-      this.connection.write(Buffer.from('\x1BM\x01', 'ascii'));
+      await this.connection.write(Buffer.from('\x1BM\x01', 'ascii'));
     }
-    super.fontChanged(current, previows);
+    return super.fontChanged(current, previows);
   }
 }

--- a/src/profile/Epson.ts
+++ b/src/profile/Epson.ts
@@ -1,7 +1,7 @@
-import {Align} from "../Align";
-import {Style} from "../Style";
-import {Cut} from "../Cut";
-import {Drawer} from "../Drawer";
+import { Align } from '../Align';
+import { Style } from '../Style';
+import { Cut } from '../Cut';
+import { Drawer } from '../Drawer';
 import { Profile } from '.';
 import { Font } from '../capabilities';
 

--- a/src/profile/Generic.ts
+++ b/src/profile/Generic.ts
@@ -1,5 +1,5 @@
 import Epson from './Epson';
-import { Style } from '../Printer';
+import {Style} from "../Style";
 
 export default class Generic extends Epson {
   protected async setMode(mode: number, enable: boolean): Promise<void> {

--- a/src/profile/Generic.ts
+++ b/src/profile/Generic.ts
@@ -1,5 +1,5 @@
 import Epson from './Epson';
-import {Style} from "../Style";
+import { Style } from '../Style';
 
 export default class Generic extends Epson {
   protected async setMode(mode: number, enable: boolean): Promise<void> {

--- a/src/profile/Generic.ts
+++ b/src/profile/Generic.ts
@@ -5,17 +5,17 @@ export default class Generic extends Epson {
   protected async setMode(mode: number, enable: boolean): Promise<void> {
     if (enable) {
       if (mode & Style.DoubleWidth) {
-        return this.connection.write(Buffer.from('\x0E', 'ascii'));
+        await this.connection.write(Buffer.from('\x0E', 'ascii'));
       }
       if (mode & Style.DoubleHeight) {
-        return this.connection.write(Buffer.from('\x1Bd1', 'ascii'));
+        await this.connection.write(Buffer.from('\x1Bd1', 'ascii'));
       }
     } else {
       if (mode & Style.DoubleHeight) {
-        return this.connection.write(Buffer.from('\x1Bd0', 'ascii'));
+        await this.connection.write(Buffer.from('\x1Bd0', 'ascii'));
       }
       if (mode & Style.DoubleWidth) {
-        return this.connection.write(Buffer.from('\x14', 'ascii'));
+        await this.connection.write(Buffer.from('\x14', 'ascii'));
       }
     }
   }

--- a/src/profile/Generic.ts
+++ b/src/profile/Generic.ts
@@ -2,25 +2,25 @@ import Epson from './Epson';
 import { Style } from '../Printer';
 
 export default class Generic extends Epson {
-  protected setMode(mode: number, enable: boolean): void {
+  protected async setMode(mode: number, enable: boolean): Promise<void> {
     if (enable) {
       if (mode & Style.DoubleWidth) {
-        this.connection.write(Buffer.from('\x0E', 'ascii'));
+        return this.connection.write(Buffer.from('\x0E', 'ascii'));
       }
       if (mode & Style.DoubleHeight) {
-        this.connection.write(Buffer.from('\x1Bd1', 'ascii'));
+        return this.connection.write(Buffer.from('\x1Bd1', 'ascii'));
       }
     } else {
       if (mode & Style.DoubleHeight) {
-        this.connection.write(Buffer.from('\x1Bd0', 'ascii'));
+        return this.connection.write(Buffer.from('\x1Bd0', 'ascii'));
       }
       if (mode & Style.DoubleWidth) {
-        this.connection.write(Buffer.from('\x14', 'ascii'));
+        return this.connection.write(Buffer.from('\x14', 'ascii'));
       }
     }
   }
 
-  async qrcode(data: string, size: number) {
-    await this.drawQrcode(data, size);
+  async qrcode(data: string, size: number): Promise<void> {
+    return this.drawQrcode(data, size);
   }
 }

--- a/src/profile/Perto.ts
+++ b/src/profile/Perto.ts
@@ -1,5 +1,5 @@
 import Elgin from './Elgin';
-import { Cut } from '../Printer';
+import {Cut} from "../Cut";
 
 export default class Perto extends Elgin {
   async buzzer(): Promise<void> {

--- a/src/profile/Perto.ts
+++ b/src/profile/Perto.ts
@@ -2,11 +2,11 @@ import Elgin from './Elgin';
 import { Cut } from '../Printer';
 
 export default class Perto extends Elgin {
-  buzzer(): void {
-    this.connection.write(Buffer.from('\x07', 'ascii'));
+  async buzzer(): Promise<void> {
+    return this.connection.write(Buffer.from('\x07', 'ascii'));
   }
 
-  cutter(_: Cut): void {
-    this.connection.write(Buffer.from('\x1BJ\x18\x1DVB(', 'ascii'));
+  async cutter(_: Cut): Promise<void> {
+    return this.connection.write(Buffer.from('\x1BJ\x18\x1DVB(', 'ascii'));
   }
 }

--- a/src/profile/Perto.ts
+++ b/src/profile/Perto.ts
@@ -1,5 +1,5 @@
 import Elgin from './Elgin';
-import {Cut} from "../Cut";
+import { Cut } from '../Cut';
 
 export default class Perto extends Elgin {
   async buzzer(): Promise<void> {

--- a/src/profile/Sweda.ts
+++ b/src/profile/Sweda.ts
@@ -1,7 +1,7 @@
 import Elgin from './Elgin';
 
 export default class Sweda extends Elgin {
-  buzzer(): void {
-    this.connection.write(Buffer.from('\x07', 'ascii'));
+  async buzzer(): Promise<void> {
+    return this.connection.write(Buffer.from('\x07', 'ascii'));
   }
 }

--- a/src/profile/index.ts
+++ b/src/profile/index.ts
@@ -27,13 +27,13 @@ export abstract class Profile {
     capability: Capability,
   ): Promise<Profile> {
     const profile = new Class(capability);
+    await profile.setCodepage(capability.codepage);
     await profile.setColumns(capability.columns);
     return profile;
   }
 
   constructor(capabilities: Capability) {
     this.capabilities = capabilities;
-    this.setCodepage(this.capabilities.codepage);
   }
 
   abstract feed(lines: number): Promise<void>;

--- a/src/profile/index.ts
+++ b/src/profile/index.ts
@@ -25,7 +25,7 @@ export abstract class Profile {
   constructor(capabilities: Capability) {
     this.capabilities = capabilities;
     this.columns = this.defaultColumns;
-    this.codepage = this.capabilities.codepage;
+    this.setCodepage(this.capabilities.codepage);
   }
 
   abstract feed(lines: number): Promise<void>;
@@ -192,8 +192,7 @@ export abstract class Profile {
     return this.capabilities.fonts;
   }
 
-  // TODO: This setter calls async methods, but cannot be async itself as it is a setter. This needs to be addressed.
-  set codepage(value: string) {
+  async setCodepage(value: string) {
     const old = this._codepage;
     const codepage = this.capabilities.codepages.find(
       ({ code }: CodePage) => value == code,
@@ -203,7 +202,7 @@ export abstract class Profile {
     }
     this._codepage = codepage;
     if (old && old.code != codepage.code) {
-      this.applyCodePage();
+      await this.applyCodePage();
     }
   }
 

--- a/src/profile/index.ts
+++ b/src/profile/index.ts
@@ -28,11 +28,11 @@ export abstract class Profile {
     this.codepage = this.capabilities.codepage;
   }
 
-  abstract feed(lines: number): void;
+  abstract feed(lines: number): Promise<void>;
 
-  abstract cutter(mode: Cut): void;
+  abstract cutter(mode: Cut): Promise<void>;
 
-  abstract buzzer(): void;
+  abstract buzzer(): Promise<void>;
 
   /**
    * @param number drawer id
@@ -43,7 +43,7 @@ export abstract class Profile {
 
   abstract set alignment(align: Align);
 
-  abstract async qrcode(data: string, size: number): Promise<void>;
+  abstract qrcode(data: string, size: number): Promise<void>;
 
   protected abstract setMode(mode: number, enable: boolean): void;
 

--- a/src/profile/index.ts
+++ b/src/profile/index.ts
@@ -45,7 +45,7 @@ export abstract class Profile {
     off_time: number,
   ): Promise<void>;
 
-  abstract set alignment(align: Align);
+  abstract setAlignment(align: Align): Promise<void>;
 
   abstract qrcode(data: string, size: number): Promise<void>;
 
@@ -72,11 +72,11 @@ export abstract class Profile {
   }
 
   async write(text: string, styles: number): Promise<void> {
-    this.setMode(styles, true);
-    this.setStyles(styles, true);
-    this.connection.write(iconv.encode(text, this._codepage.code));
-    this.setStyles(styles, false);
-    this.setMode(styles, false);
+    await this.setMode(styles, true);
+    await this.setStyles(styles, true);
+    await this.connection.write(iconv.encode(text, this._codepage.code));
+    await this.setStyles(styles, false);
+    await this.setMode(styles, false);
   }
 
   async withStyle(styleConf: StyleConf, cb: Function): Promise<void> {
@@ -94,7 +94,7 @@ export abstract class Profile {
     if (underline) styles |= Style.Underline;
 
     if (align !== Align.Left) {
-      this.alignment = align;
+      await this.setAlignment(align);
     }
     await this.setCharSize({ width, height });
     await this.setStyles(styles, true);
@@ -102,14 +102,14 @@ export abstract class Profile {
     await this.setStyles(styles, false);
     await this.setCharSize({ width: 1, height: 1 });
     if (align !== Align.Left) {
-      this.alignment = Align.Left;
+      await this.setAlignment(Align.Left);
     }
   }
 
   async writeln(text: string, styles: number, align: Align): Promise<void> {
     // apply other alignment
     if (align !== Align.Left) {
-      this.alignment = align;
+      await this.setAlignment(align);
     }
     if (text.length > 0) {
       await this.write(text, styles);
@@ -117,7 +117,7 @@ export abstract class Profile {
     await this.feed(1);
     // reset align to left
     if (align !== Align.Left) {
-      this.alignment = Align.Left;
+      return this.setAlignment(Align.Left);
     }
   }
 

--- a/src/profile/index.ts
+++ b/src/profile/index.ts
@@ -1,6 +1,9 @@
 import { Connection } from '../connection';
 import { Font, Capability, CodePage } from '../capabilities';
-import { Align, Drawer, Style, Cut } from '../Printer';
+import { Align } from '../Align';
+import { Style } from '../Style';
+import { Cut } from '../Cut';
+import { Drawer } from '../Drawer';
 import * as iconv from 'iconv-lite';
 import * as QRCode from 'qrcode';
 import Image from '../graphics/Image';
@@ -21,16 +24,6 @@ export abstract class Profile {
   private _font: Font;
   private _connection: Connection;
   protected capabilities: Capability;
-
-  static async initialise(
-    Class: new (capability: Capability) => Profile,
-    capability: Capability,
-  ): Promise<Profile> {
-    const profile = new Class(capability);
-    await profile.setCodepage(capability.codepage);
-    await profile.setColumns(capability.columns);
-    return profile;
-  }
 
   constructor(capabilities: Capability) {
     this.capabilities = capabilities;
@@ -217,6 +210,8 @@ export abstract class Profile {
   protected async fontChanged(_: Font, __: Font) {}
 
   async initialize(): Promise<void> {
+    await this.setCodepage(this.capabilities.codepage);
+    await this.setColumns(this.capabilities.columns);
     if (this.capabilities.initialize) {
       await this.connection.write(
         Buffer.from(this.capabilities.initialize, 'ascii'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2802,10 +2802,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@~1.18.2:
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
-  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+prettier@~1.19.0:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 pretty-format@^24.9.0:
   version "24.9.0"


### PR DESCRIPTION
Hello!

Theo here - another engineer from @elephant-healthcare, it seems you've worked with the wonderful @noisyscanner in the past. Thanks for the awesome package you've written, it's amazing stuff 🤘 You'll be pleased to hear its being used to assist in saving lives in many LEDCs.

I have for you a fairly big change to this package and to its interface, so have opted to bump the major number. I hope you like what you see 😊

# Problem brief

Almost all [w3c web usb functions](https://wicg.github.io/webusb/#usbdevice-methods), as typed by `@types/w3c-web-usb`, are async. In the existing implementation of WebUSB this behaviour was hidden, with all methods providing sync return values.

This meant that should an error occur during any open/write/close, such as the printer having been disconnected, these errors would be uncatchable by the consumer of the package, as they would be thrown outside the main 'thread'. i.e.

```js
try {
  await printer.writeLn('Foo') // The await has no effect as writeLn is sync
} catch (e) {
  // So, this can never be reached
}
```

## Proposed changes

- Makes all Connection interface methods async.
- Replaces all constructors that perform async work with sync constructors that set fields, and add static async factory methods to perform and await any async work.
- Pulls any calls to the printer in profile constructors into their `initialize` steps - which fixes a 🐛 where the printer could be asked to apply codepages, styles etc before we've even connected.
- Alters the main interface of the package, to allow you to pass in the model name
  - Adds strict typing to the supported model string, so you can only use one in our capabilities list.

## Reasoning

I opted for async factory methods that call initialize as opposed to adding initialization checks to each method call, as this felt less invasive of a change. This also wouldn't require a test being written for every method, nor managing the state of having been initialized.

## Testing

All tests are passing and no .bin test files have been changed. The only place this looks a little unclean is in the `Daruma.initialize` method, where I was unable to use the `super.initialize` without the the calls to the printer being done in a different order. I wasn't keen to change the bin files, as couldn't be certain of the importance of the ordering.

Have also tested this with a printer connected and it works successfully.

# Other

This also bumps Prettier to support the nullish function call operator `foo?.()` https://github.com/prettier/prettier/issues/6609