### PR TITLE
Exports the pngjs PNG class from the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "escpos-buffer",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Library to generate buffer for thermal printers.",
   "author": "GrandChef Team <desenvolvimento@grandchef.com.br>",
   "license": "MIT",
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@types/jest": "^24.0.21",
     "@types/node": "^12.12.5",
+    "@types/pngjs": "^6.0.1",
     "@types/w3c-web-usb": "1.0.4",
     "jest": "~24.9.0",
     "prettier": "~1.19.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ export { default as Image } from './graphics/Image';
 export * from './graphics/filter';
 export * from './Printer';
 export { default as Printer } from './Printer';
+export * from 'pngjs';

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,4 +5,4 @@ export { default as Image } from './graphics/Image';
 export * from './graphics/filter';
 export * from './Printer';
 export { default as Printer } from './Printer';
-export * from 'pngjs';
+export { PNG } from 'pngjs';

--- a/yarn.lock
+++ b/yarn.lock
@@ -429,10 +429,22 @@
   dependencies:
     jest-diff "^24.3.0"
 
+"@types/node@*":
+  version "17.0.21"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.21.tgz#864b987c0c68d07b4345845c3e63b75edd143644"
+  integrity sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==
+
 "@types/node@^12.12.5":
   version "12.20.36"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.36.tgz#5bd54d2383e714fc4d2c258107ee70c5bad86d0c"
   integrity sha512-+5haRZ9uzI7rYqzDznXgkuacqb6LJhAti8mzZKWxIXn/WEtvB+GHVJ7AuMwcN1HMvXOSJcrvA6PPoYHYOYYebA==
+
+"@types/pngjs@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@types/pngjs/-/pngjs-6.0.1.tgz#c711ec3fbbf077fed274ecccaf85dd4673130072"
+  integrity sha512-J39njbdW1U/6YyVXvC9+1iflZghP8jgRf2ndYghdJb5xL49LYDB+1EuAxfbuJ2IBbWIL3AjHPQhgaTxT3YaYeg==
+  dependencies:
+    "@types/node" "*"
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"


### PR DESCRIPTION
Hey again! Just a very small change here this time. Hope this works for you 😊 Thanks as always for being so responsive to this stuff 🤘

## Feature

I would like to export the `PNG` class from `pngjs` from this library.

### Reasoning

This is because [the `Image` class can accept an instance of a `PNG` in its constructor](https://github.com/grandchef/escpos-buffer/blob/a992707351fefbd66aaecd8203a451c215398965/src/graphics/Image.ts#L12). However, we're currently facing an issue where the versions of the `pngjs` class are misaligning between this library and our code, so the [`input instanceof PNG` comparison in the constructor](https://github.com/grandchef/escpos-buffer/blob/a992707351fefbd66aaecd8203a451c215398965/src/graphics/Image.ts#L15) returns false incorrectly.