### PR TITLE
feat: add cp874 (thai)

### DIFF
--- a/src/capabilities.ts
+++ b/src/capabilities.ts
@@ -423,6 +423,7 @@ const capabilities = {
         cp864: '\x1Bt\x0E',
         cp862: '\x1Bt\x0F',
         iso88592: '\x1Bt\x10',
+        cp874: '\x1Bt\x1E',
       },
     },
   },


### PR DESCRIPTION
Added support for Thai characters for some Chinese OEM thermal printers that using the POS-80 driver.

![image](https://github.com/grandchef/escpos-buffer/assets/23092256/6be2f0ed-38f8-4eaa-9f35-274784a452c6)

**References**
https://github.com/NielsLeenheer/EscPosEncoder/issues/20#issuecomment-987243929
https://github.com/NielsLeenheer/EscPosEncoder/blob/master/src/esc-pos-encoder.js#L156